### PR TITLE
chore: remove unnecessary aria labels (PT-188528220)

### DIFF
--- a/src/components/chat-transcript.test.tsx
+++ b/src/components/chat-transcript.test.tsx
@@ -33,11 +33,9 @@ describe("test chat transcript component", () => {
       expect(message).toHaveAttribute("aria-label", labelContent);
 
       const speaker = within(message).getByTestId("chat-message-speaker");
-      expect(speaker).toHaveAttribute("aria-label", "speaker");
       expect(speaker).toHaveTextContent(chatTranscript.messages[index].speaker);
 
       const content = within(message).getByTestId("chat-message-content");
-      expect(content).toHaveAttribute("aria-label", "message");
       expect(content).toHaveTextContent(chatTranscript.messages[index].content);
     });
   });

--- a/src/components/chat-transcript.tsx
+++ b/src/components/chat-transcript.tsx
@@ -37,10 +37,10 @@ export const ChatTranscriptComponent = ({chatTranscript}: IProps) => {
               key={message.timestamp}
               role="listitem"
             >
-              <h3 aria-label="speaker" data-testid="chat-message-speaker">
+              <h3 data-testid="chat-message-speaker">
                 {message.speaker}
               </h3>
-              <p aria-label="message" data-testid="chat-message-content">
+              <p data-testid="chat-message-content">
                 {message.content}
               </p>
             </section>


### PR DESCRIPTION
[#188528220](https://www.pivotaltracker.com/story/show/188528220)

As noted in the PT story comments, the use of `arial-label` with value "speaker" on the `h3` elements was causing screen readers to say "heading level 3 - speaker" instead of "heading level 3 - DAVAI" or "heading level 3 - User" which is more appropriate for identifying the speaker. The latter is what screen readers say when the `aria-label` attribute is removed. Even though the `aria-label` on associated `p` elements wasn't causing a similar problem with the message content, I removed that, too, since it doesn't seem like it's appropriate use of the `aria-label` attribute. Plus, the [`p` element doesn't support `aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label#associated_roles).