### PR TITLE
[DAVAI-10]: Sonify univariate dot plot

### DIFF
--- a/__mocks__/tone.js
+++ b/__mocks__/tone.js
@@ -4,6 +4,11 @@ module.exports = {
     triggerAttackRelease: jest.fn(),
     toDestination: jest.fn(),
   })),
+  MonoSynth: jest.fn(() => ({
+    connect: jest.fn(),
+    triggerAttackRelease: jest.fn(),
+    toDestination: jest.fn(),
+  })),
   Panner: jest.fn(() => ({
     toDestination: jest.fn(),
   })),

--- a/__mocks__/tone.js
+++ b/__mocks__/tone.js
@@ -4,13 +4,22 @@ module.exports = {
     triggerAttackRelease: jest.fn(),
     toDestination: jest.fn(),
   })),
-  MonoSynth: jest.fn(() => ({
+  Oscillator: jest.fn(() => ({
     connect: jest.fn(),
-    triggerAttackRelease: jest.fn(),
-    toDestination: jest.fn(),
+    rampTo: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
   })),
   Panner: jest.fn(() => ({
     toDestination: jest.fn(),
+  })),
+  Gain: jest.fn(() => ({
+    toDestination: jest.fn(() => ({
+      connect: jest.fn(),
+      gain: jest.fn(() => ({
+        rampTo: jest.fn()
+      })),
+    })),
   })),
   getTransport: jest.fn(() => ({
     start: jest.fn(),
@@ -20,5 +29,4 @@ module.exports = {
   })),
   start: jest.fn(),
   stop: jest.fn(),
-
 };

--- a/src/components/graph-sonification-utils.ts
+++ b/src/components/graph-sonification-utils.ts
@@ -24,6 +24,9 @@ export const mapValueToStereoPan = (value: number, min: number, max: number) => 
   return normalizedPosition * 2 - 1;
 };
 
+// note: this binning logic is taken from CODAP itself, since the API doesn't support binning directly
+// the original code can be found here:
+// https://github.com/concord-consortium/codap/blob/main/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot-model.ts#L61
 export const computeCodapBins = (values: number[]): IBinParams => {
   let minValue = Infinity;
   let maxValue = -Infinity;
@@ -63,7 +66,6 @@ export function binUsingCodapEdges(values: number[], binParams: IBinParams) {
     // clamp v so we don't go out of range
     if (v < minBinEdge) v = minBinEdge;
     if (v >= maxBinEdge) v = maxBinEdge - 1e-9; // so we fall in the last bin
-    // figure out which bin
     const idx = Math.floor((v - minBinEdge) / numBins);
     if (idx >= 0 && idx < totalNumberOfBins) {
       bins[idx]++;

--- a/src/components/graph-sonification-utils.ts
+++ b/src/components/graph-sonification-utils.ts
@@ -1,5 +1,15 @@
 import { codapInterface } from "@concord-consortium/codap-plugin-api";
 
+interface IBinParams {
+  binAlignment: number;
+  binWidth: number;
+  minBinEdge: number;
+  maxBinEdge: number;
+  minValue: number;
+  maxValue: number;
+  totalNumberOfBins: number;
+}
+
 export const mapPitchFractionToFrequency = (pitchFraction: number) => {
   const lowerFreqBound = 220;
   const upperFreqBound = 880;
@@ -13,6 +23,54 @@ export const mapValueToStereoPan = (value: number, min: number, max: number) => 
   const normalizedPosition = distanceFromMin / totalRange;
   return normalizedPosition * 2 - 1;
 };
+
+export const computeCodapBins = (values: number[]): IBinParams => {
+  let minValue = Infinity;
+  let maxValue = -Infinity;
+  values.forEach(v => {
+    if (Number.isFinite(v)) {
+      minValue = Math.min(minValue, v);
+      maxValue = Math.max(maxValue, v);
+    }
+  });
+
+  const binWidth = 10;
+  const binAlignment = Math.floor(minValue / binWidth) * binWidth;
+  const diff = binAlignment - minValue;
+  const minBinEdge = binAlignment - Math.ceil(diff / binWidth) * binWidth;
+  const totalNumberOfBins = Math.ceil((maxValue - minBinEdge) / binWidth + 0.000001);
+  const maxBinEdge = minBinEdge + (totalNumberOfBins * binWidth);
+
+  return {
+    binAlignment,
+    binWidth,
+    minBinEdge,
+    maxBinEdge,
+    minValue,
+    maxValue,
+    totalNumberOfBins
+  };
+};
+
+export function binUsingCodapEdges(values: number[], binParams: IBinParams) {
+  const {
+    minBinEdge, maxBinEdge, binWidth, totalNumberOfBins
+  } = binParams;
+
+  const bins = Array(totalNumberOfBins).fill(0);
+  values.forEach((v) => {
+    if (!Number.isFinite(v)) return;
+    // clamp v so we don't go out of range
+    if (v < minBinEdge) v = minBinEdge;
+    if (v >= maxBinEdge) v = maxBinEdge - 1e-9; // so we fall in the last bin
+    // figure out which bin
+    const idx = Math.floor((v - minBinEdge) / binWidth);
+    if (idx >= 0 && idx < totalNumberOfBins) {
+      bins[idx]++;
+    }
+  });
+  return bins;
+}
 
 export const updateRoiAdornment = async (graphName: string, fraction: number) => {
   await codapInterface.sendRequest({

--- a/src/components/graph-sonification-utils.ts
+++ b/src/components/graph-sonification-utils.ts
@@ -2,7 +2,7 @@ import { codapInterface } from "@concord-consortium/codap-plugin-api";
 
 interface IBinParams {
   binAlignment: number;
-  binWidth: number;
+  numBins: number;
   minBinEdge: number;
   maxBinEdge: number;
   minValue: number;
@@ -34,16 +34,16 @@ export const computeCodapBins = (values: number[]): IBinParams => {
     }
   });
 
-  const binWidth = 10;
-  const binAlignment = Math.floor(minValue / binWidth) * binWidth;
+  const numBins = 10;
+  const binAlignment = Math.floor(minValue / numBins) * numBins;
   const diff = binAlignment - minValue;
-  const minBinEdge = binAlignment - Math.ceil(diff / binWidth) * binWidth;
-  const totalNumberOfBins = Math.ceil((maxValue - minBinEdge) / binWidth + 0.000001);
-  const maxBinEdge = minBinEdge + (totalNumberOfBins * binWidth);
+  const minBinEdge = binAlignment - Math.ceil(diff / numBins) * numBins;
+  const totalNumberOfBins = Math.ceil((maxValue - minBinEdge) / numBins + 0.000001);
+  const maxBinEdge = minBinEdge + (totalNumberOfBins * numBins);
 
   return {
     binAlignment,
-    binWidth,
+    numBins,
     minBinEdge,
     maxBinEdge,
     minValue,
@@ -54,7 +54,7 @@ export const computeCodapBins = (values: number[]): IBinParams => {
 
 export function binUsingCodapEdges(values: number[], binParams: IBinParams) {
   const {
-    minBinEdge, maxBinEdge, binWidth, totalNumberOfBins
+    minBinEdge, maxBinEdge, numBins, totalNumberOfBins
   } = binParams;
 
   const bins = Array(totalNumberOfBins).fill(0);
@@ -64,7 +64,7 @@ export function binUsingCodapEdges(values: number[], binParams: IBinParams) {
     if (v < minBinEdge) v = minBinEdge;
     if (v >= maxBinEdge) v = maxBinEdge - 1e-9; // so we fall in the last bin
     // figure out which bin
-    const idx = Math.floor((v - minBinEdge) / binWidth);
+    const idx = Math.floor((v - minBinEdge) / numBins);
     if (idx >= 0 && idx < totalNumberOfBins) {
       bins[idx]++;
     }

--- a/src/components/graph-sonification.tsx
+++ b/src/components/graph-sonification.tsx
@@ -147,7 +147,8 @@ export const GraphSonification = ({availableGraphs, selectedGraph, onSelectGraph
         Tone.getTransport().scheduleOnce((time) => {
           const countFraction = count / (Math.max(...bins) || 1);
           const freq = mapPitchFractionToFrequency(countFraction);
-          const panValue = mapValueToStereoPan(timeValues[i], xLowerBound, xUpperBound);
+          const binAvgForPanValue = binParams.minBinEdge + (i + 0.5) * binParams.numBins;
+          const panValue = mapValueToStereoPan(binAvgForPanValue, binParams.minBinEdge, binParams.maxBinEdge);
           pannerRef.current?.pan.setValueAtTime(panValue, time);
           monoSynthRef.current?.triggerAttackRelease(freq, binDuration, time);
         }, offset);

--- a/src/components/graph-sonification.tsx
+++ b/src/components/graph-sonification.tsx
@@ -281,7 +281,7 @@ export const GraphSonification = ({availableGraphs, selectedGraph, onSelectGraph
     if (selectedGraph) {
       mapValuesToTimeAndPitch(selectedGraph);
     }
-  }, [selectedGraph]);
+  }, [selectedGraph, selectedGraph?.xAttributeID, selectedGraph?.yAttributeID]);
 
   useEffect(() => {
     return () => {

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -385,7 +385,7 @@ export const AssistantModel = types
                   root.sonificationStore.setSelectedGraph(graph);
                   outputMsg = `The graph "${graphName}" is ready to be sonified. Tell the user they can use the sonification controls to hear it.`;
                 } else {
-                  outputMsg = `The graph "${graphName}" is not a numeric scatter plot. Tell the user they must select a numeric scatter plot or a univariate dot plot.`;
+                  outputMsg = `The graph "${graphName}" is not able to be sonified. Tell the user they must select a numeric scatter plot or a univariate dot plot.`;
                 }
 
                 return { tool_call_id: toolCall.id, output: outputMsg };

--- a/src/models/graph-sonification-model.ts
+++ b/src/models/graph-sonification-model.ts
@@ -1,12 +1,16 @@
 import { types } from "mobx-state-tree";
+import { ICODAPGraph } from "../types";
 
 export const GraphSonificationModel = types
   .model("GraphSonificationModel", {
-    selectedGraph: types.optional(types.frozen(), {}),
+    selectedGraph: types.maybe(types.frozen<ICODAPGraph>()),
   })
   .actions((self) => ({
-    setSelectedGraph(graph: Record<string, any>) {
+    setSelectedGraph(graph: ICODAPGraph) {
       self.selectedGraph = graph;
+    },
+    removeSelectedGraph() {
+      self.selectedGraph = undefined;
     }
   }));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,12 +114,12 @@ export interface ICODAPGraph {
   topSplitAttributeName?: string;
   transparent?: boolean;
   type?: string;
-  xAttributeID?: string;
+  xAttributeID?: number;
   xAttributeName?: string;
   xAttributeType?: string;
   xLowerBound?: number;
   xUpperBound?: number;
-  y2AttributeID?: string;
+  y2AttributeID?: number;
   y2AttributeName?: string;
   y2AttributeType?: string;
   y2LowerBound?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,3 +69,66 @@ export interface CodapItem {
 }
 
 export type Action = "create" | "get" | "update" | "delete";
+
+export interface ICODAPComponentListItem {
+  hidden: boolean;
+  id: number;
+  name: string;
+  title: string;
+  type: "caseTable" | "graph" | "map" | "text" | "slider";
+}
+
+export interface ICODAPGraph {
+  backgroundColor?: string;
+  cannotClose?: boolean;
+  captionAttributeID?: string;
+  captionAttributeName?: string;
+  dataContext?: string;
+  dimensions?: {
+    width: number;
+    height: number;
+  };
+  displayOnlySelectedCases?: boolean;
+  enableNumberToggle?: boolean;
+  filterFormula?: string;
+  hiddenCases?: any[];
+  id: number;
+  legendAttributeID?: string;
+  legendAttributeName?: string;
+  name?: string;
+  numberToggleLastMode?: string;
+  plotType?: string;
+  pointColor?: string;
+  pointSize?: number;
+  position?: {
+    left: number;
+    top: number;
+  };
+  rightSplitAttributeID?: string;
+  rightSplitAttributeName?: string;
+  showMeasuresForSelection?: boolean;
+  strokeColor?: string;
+  strokeSameAsFill?: boolean;
+  title?: string;
+  topSplitAttributeID?: string;
+  topSplitAttributeName?: string;
+  transparent?: boolean;
+  type?: string;
+  xAttributeID?: string;
+  xAttributeName?: string;
+  xAttributeType?: string;
+  xLowerBound?: number;
+  xUpperBound?: number;
+  y2AttributeID?: string;
+  y2AttributeName?: string;
+  y2AttributeType?: string;
+  y2LowerBound?: number;
+  y2UpperBound?: number;
+  yAttributeID?: number;
+  yAttributeIDs?: number[];
+  yAttributeName?: string;
+  yAttributeNames?: string[];
+  yAttributeType?: string;
+  yLowerBound?: number;
+  yUpperBound?: number;
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,18 @@
 import * as Tone from "tone";
+import { ICODAPGraph } from "../types";
+
+export const checkIsValidGraph = (graph: ICODAPGraph) => {
+  const {
+    plotType,
+    topSplitAttributeID: topId,
+    y2AttributeID: y2Id,
+    xAttributeID: xId,
+    yAttributeID: yId,
+    rightSplitAttributeID: rightId
+  } = graph;
+  const isUniDotPlot = (plotType === "dotPlot" || plotType === "binnedDotPlot") && !topId && !rightId && !y2Id && ((xId && !yId) || (yId && !xId));
+  return plotType === "scatterPlot" || isUniDotPlot;
+};
 
 export const timeStamp = (): string => {
   const now = new Date();


### PR DESCRIPTION
Implements the following support for sonifying univariate dot plots:
- Bin the dots into 10 evenly spaced bins and counts the values in each bin
- Create a tone that transitions from one count to the next with the count setting the pitch of the tone

Note: CODAP does not currently support updating a graph to use bins via the API, so we just figure out the bins in the plugin, and animate the line across the graph as usual. If you do bin the graph via the component itself in CODAP, the tones match up pretty neatly with the adornment line vis a vis the bins.