### PR TITLE
[DAVAI-13]: Sonify univariate dot plot

### DIFF
--- a/__mocks__/tone.js
+++ b/__mocks__/tone.js
@@ -11,8 +11,22 @@ module.exports = {
     triggerAttackRelease: jest.fn(),
     toDestination: jest.fn(),
   })),
+  Oscillator: jest.fn(() => ({
+    connect: jest.fn(),
+    rampTo: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+  })),
   Panner: jest.fn(() => ({
     toDestination: jest.fn(),
+  })),
+  Gain: jest.fn(() => ({
+    toDestination: jest.fn(() => ({
+      connect: jest.fn(),
+      gain: jest.fn(() => ({
+        rampTo: jest.fn()
+      })),
+    })),
   })),
   start: jest.fn(),
   stop: jest.fn(),

--- a/__mocks__/tone.js
+++ b/__mocks__/tone.js
@@ -21,11 +21,10 @@ module.exports = {
     toDestination: jest.fn(),
   })),
   Gain: jest.fn(() => ({
-    toDestination: jest.fn(() => ({
-      connect: jest.fn(),
-      gain: jest.fn(() => ({
-        rampTo: jest.fn()
-      })),
+    connect: jest.fn(),
+    rampTo: jest.fn(),
+    gain: jest.fn(() => ({
+      rampTo: jest.fn()
     })),
   })),
   start: jest.fn(),

--- a/src/hooks/use-root-store.ts
+++ b/src/hooks/use-root-store.ts
@@ -7,6 +7,7 @@ import { DAVAI_SPEAKER, GREETING } from "../constants";
 import { timeStamp } from "../utils/utils";
 import { RootStore } from "../models/root-store";
 import { GraphSonificationModel } from "../models/graph-sonification-model";
+import { BinModel } from "../models/bin-model";
 
 export const useRootStore = () => {
   const apiConnection = useOpenAIContext();
@@ -32,7 +33,10 @@ export const useRootStore = () => {
       }),
       sonificationStore: GraphSonificationModel.create({
         selectedGraph: undefined,
-      }),
+        binValues: BinModel.create({
+          values: []
+        }),
+      })
     });
   }, [apiConnection, assistantId]);
 

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -330,9 +330,8 @@ export const AssistantModel = types
               } else if (toolCall.function.name === "sonify_graph") {
                 const root = getRoot(self) as any;
                 const graph = yield getGraphByID(parsedResult.data.graphID);
-                const isValid = isGraphValidType(graph);
 
-                if (isValid) {
+                if (isGraphValidType(graph)) {
                   root.sonificationStore.setSelectedGraphID(graph.id);
                   output = `The graph "${graph.name || graph.id}" is ready to be sonified. Tell the user they can use the sonification controls to hear it.`;
                 } else {

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -3,7 +3,7 @@ import { OpenAI } from "openai";
 import { Message } from "openai/resources/beta/threads/messages";
 import { codapInterface } from "@concord-consortium/codap-plugin-api";
 import { DAVAI_SPEAKER, DEBUG_SPEAKER, WAIT_STATES, ERROR_STATES } from "../constants";
-import { convertBase64ToImage, formatJsonMessage, getGraphByID, getDataContexts, getParsedData } from "../utils/utils";
+import { convertBase64ToImage, formatJsonMessage, getGraphByID, getDataContexts, getParsedData, isGraphValidType } from "../utils/utils";
 import { requestThreadDeletion } from "../utils/openai-utils";
 import { ChatTranscriptModel } from "./chat-transcript-model";
 
@@ -330,12 +330,13 @@ export const AssistantModel = types
               } else if (toolCall.function.name === "sonify_graph") {
                 const root = getRoot(self) as any;
                 const graph = yield getGraphByID(parsedResult.data.graphID);
+                const isValid = isGraphValidType(graph);
 
-                if (graph.plotType === "scatterPlot") {
+                if (isValid) {
                   root.sonificationStore.setSelectedGraphID(graph.id);
                   output = `The graph "${graph.name || graph.id}" is ready to be sonified. Tell the user they can use the sonification controls to hear it.`;
                 } else {
-                  output = `The graph "${graph.name || graph.id}" is not a numeric scatter plot. Tell the user they must select a numeric scatter plot.`;
+                  output = `The graph "${graph.name || graph.id}" is not a numeric scatter plot or univariate dot plot. Tell the user they must select a numeric scatter plot or univariate dot plot to proceed.`;
                 }
               } else {
                 output = `The tool call "${toolCall.function.name}" is not recognized.`;

--- a/src/models/bin-model.ts
+++ b/src/models/bin-model.ts
@@ -1,0 +1,76 @@
+import { Instance, types } from "mobx-state-tree";
+
+// note: this binning logic is taken from CODAP itself, since the API doesn't support binning directly
+// the original code can be found here:
+// https://github.com/concord-consortium/codap/blob/main/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot-model.ts#L61
+export const BinModel = types.model("BinModel", {
+  values: types.optional(types.array(types.number), []),
+})
+.views((self) => ({
+  get minValue() {
+    if (self.values.length === 0) return 0;
+    return Math.min(...self.values);
+  },
+  get maxValue() {
+    if (self.values.length === 0) return 0;
+    return Math.max(...self.values);
+  },
+}))
+.views((self) => ({
+  get binWidth () {
+    const kNumBins = 4;
+    const binRange = self.maxValue !== self.minValue
+      ? (self.maxValue - self.minValue) / kNumBins
+      : 1 / kNumBins;
+    // Convert to a logarithmic scale (base 10)
+    const logRange = Math.log(binRange) / Math.LN10;
+    const significantDigit = Math.pow(10.0, Math.floor(logRange));
+    // Determine the scale factor based on the significant digit
+    const scaleFactor = Math.pow(10.0, logRange - Math.floor(logRange));
+    const adjustedScaleFactor = scaleFactor < 2 ? 1 : scaleFactor < 5 ? 2 : 5;
+    return Math.max(significantDigit * adjustedScaleFactor, Number.MIN_VALUE);
+  }
+}))
+.views((self) => ({
+  get minBinEdge() {
+    if (self.values.length === 0) return 0;
+    const binAlignment = Math.floor(self.minValue / self.binWidth) * self.binWidth;
+    const diff = binAlignment - self.minValue;
+    return binAlignment - Math.ceil(diff / self.binWidth) * self.binWidth;
+  }
+}))
+.views((self) => ({
+  get totalNumberOfBins() {
+    if (self.values.length === 0) return 0;
+    return Math.ceil((self.maxValue - self.minBinEdge) / self.binWidth + 0.000001);
+  }
+}))
+.views((self) => ({
+  get maxBinEdge() {
+    return self.minBinEdge + (self.totalNumberOfBins * self.binWidth);
+  }
+}))
+.views((self) => ({
+  get bins() {
+    if (!self.values || self.values.length === 0) return [];
+    const bins = Array(self.totalNumberOfBins).fill(0);
+    self.values.forEach((v) => {
+      if (!Number.isFinite(v)) return;
+      // clamp v so we don't go out of range
+      if (v < self.minBinEdge) v = self.minBinEdge;
+      if (v >= self.maxBinEdge) v = self.maxBinEdge - 1e-9; // so we fall in the last bin
+      const idx = Math.floor((v - self.minBinEdge) / self.binWidth);
+      if (idx >= 0 && idx < self.totalNumberOfBins) {
+        bins[idx]++;
+      }
+    });
+    return bins;
+  }
+}))
+.actions((self) => ({
+  setValues(values: number[]) {
+    self.values?.replace(values);
+  }
+}));
+
+export interface IBinModel extends Instance<typeof BinModel> {}

--- a/src/models/codap-graph-model.ts
+++ b/src/models/codap-graph-model.ts
@@ -59,28 +59,6 @@ export const CODAPGraphModel = types.model("ICODAPGraph", {
   yLowerBound: types.maybe(types.number),
   yUpperBound: types.maybe(types.number),
 })
-.views((self) => ({
-  get isUnivariateDotPlot() {
-    const {
-      plotType,
-      topSplitAttributeID: topId,
-      y2AttributeID: y2Id,
-      xAttributeID: xId,
-      yAttributeID: yId,
-      rightSplitAttributeID: rightId
-    } = self;
-    const isDotPlot = plotType === "dotPlot" || plotType === "binnedDotPlot";
-    return isDotPlot && (!topId && !rightId && !y2Id && ((xId && !yId) || (yId && !xId)));
-  },
-  get isScatterPlot() {
-    return self.plotType === "scatterPlot";
-  }
-}))
-.views((self) => ({
-  get isValidType () {
-    return self.isScatterPlot || self.isUnivariateDotPlot;
-  }
-}))
 .actions((self) => ({
   updatePropsFromSnapshot(snapshot: Partial<SnapshotIn<typeof CODAPGraphModel>>) {
     Object.keys(snapshot).forEach((key) => {

--- a/src/models/codap-graph-model.ts
+++ b/src/models/codap-graph-model.ts
@@ -59,12 +59,34 @@ export const CODAPGraphModel = types.model("ICODAPGraph", {
   yLowerBound: types.maybe(types.number),
   yUpperBound: types.maybe(types.number),
 })
+.views((self) => ({
+  get isUnivariateDotPlot() {
+    const {
+      plotType,
+      topSplitAttributeID: topId,
+      y2AttributeID: y2Id,
+      xAttributeID: xId,
+      yAttributeID: yId,
+      rightSplitAttributeID: rightId
+    } = self;
+    const isDotPlot = plotType === "dotPlot" || plotType === "binnedDotPlot";
+    return isDotPlot && (!topId && !rightId && !y2Id && ((xId && !yId) || (yId && !xId)));
+  },
+  get isScatterPlot() {
+    return self.plotType === "scatterPlot";
+  }
+}))
+.views((self) => ({
+  get isValidType () {
+    return self.isScatterPlot || self.isUnivariateDotPlot;
+  }
+}))
 .actions((self) => ({
   updatePropsFromSnapshot(snapshot: Partial<SnapshotIn<typeof CODAPGraphModel>>) {
     Object.keys(snapshot).forEach((key) => {
       const typedKey = key as keyof SnapshotIn<typeof CODAPGraphModel>;
       const newValue = snapshot[typedKey];
-      if (newValue !== undefined && self[typedKey] !== newValue) {
+      if (self[typedKey] !== newValue) {
         // @ts-expect-error: TypeScript may complain about dynamic assignment
         self[typedKey] = newValue;
       }

--- a/src/models/graph-sonification-model.ts
+++ b/src/models/graph-sonification-model.ts
@@ -5,6 +5,7 @@ import { getAllItems } from "@concord-consortium/codap-plugin-api";
 import { removeRoiAdornment } from "../components/graph-sonification-utils";
 import { CODAPGraphModel, ICODAPGraphModel } from "./codap-graph-model";
 import { BinModel } from "./bin-model";
+import { isGraphValidType } from "../utils/utils";
 
 export const GraphSonificationModel = types
   .model("GraphSonificationModel", {
@@ -15,7 +16,7 @@ export const GraphSonificationModel = types
   })
   .views((self) => ({
     get validGraphs() {
-      return self.allGraphs?.filter((graph: ICODAPGraphModel) => graph.isValidType) || [];
+      return self.allGraphs?.filter((graph: ICODAPGraphModel) => isGraphValidType(graph)) || [];
     }
   }))
   .views((self) => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,7 @@ export interface ICODAPGraph {
   filterFormula?: string;
   hiddenCases?: any[];
   id: number;
-  legendAttributeID?: string;
+  legendAttributeID?: number;
   legendAttributeName?: string;
   name?: string;
   numberToggleLastMode?: string;
@@ -105,13 +105,13 @@ export interface ICODAPGraph {
     top: number;
   };
   primaryAxis?: string;
-  rightSplitAttributeID?: string;
+  rightSplitAttributeID?: number;
   rightSplitAttributeName?: string;
   showMeasuresForSelection?: boolean;
   strokeColor?: string;
   strokeSameAsFill?: boolean;
   title?: string;
-  topSplitAttributeID?: string;
+  topSplitAttributeID?: number;
   topSplitAttributeName?: string;
   transparent?: boolean;
   type?: string;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,6 @@
 import { codapInterface, IResult, getListOfDataContexts, getDataContext,  } from "@concord-consortium/codap-plugin-api";
 import * as Tone from "tone";
-import { ICODAPComponentListItem } from "../types";
+import { ICODAPComponentListItem, ICODAPGraph } from "../types";
 
 export const timeStamp = (): string => {
   const now = new Date();
@@ -176,4 +176,18 @@ export const getParsedData = (toolCall: any) => {
   } catch {
     return { ok: false, data: null };
   }
+};
+
+export const isGraphValidType = (graph: ICODAPGraph) => {
+  const {
+    plotType,
+    topSplitAttributeID: topId,
+    y2AttributeID: y2Id,
+    xAttributeID: xId,
+    yAttributeID: yId,
+    rightSplitAttributeID: rightId
+  } = graph;
+  const isDotPlot = plotType === "dotPlot" || plotType === "binnedDotPlot";
+  const isUnivariateDotPlot = isDotPlot && !topId && !rightId && !y2Id && ((xId && !yId) || (yId && !xId));
+  return graph.plotType === "scatterPlot" || isUnivariateDotPlot;
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -178,16 +178,26 @@ export const getParsedData = (toolCall: any) => {
   }
 };
 
-export const isGraphValidType = (graph: ICODAPGraph) => {
+export function isUnivariateDotPlot(graph: ICODAPGraph): boolean {
   const {
     plotType,
     topSplitAttributeID: topId,
+    rightSplitAttributeID: rightId,
     y2AttributeID: y2Id,
     xAttributeID: xId,
-    yAttributeID: yId,
-    rightSplitAttributeID: rightId
+    yAttributeID: yId
   } = graph;
+
   const isDotPlot = plotType === "dotPlot" || plotType === "binnedDotPlot";
-  const isUnivariateDotPlot = isDotPlot && !topId && !rightId && !y2Id && ((xId && !yId) || (yId && !xId));
-  return graph.plotType === "scatterPlot" || isUnivariateDotPlot;
-};
+  const hasExactlyOneAxis = (xId && !yId) || (yId && !xId);
+
+  return !!(isDotPlot
+    && !topId
+    && !rightId
+    && !y2Id
+    && hasExactlyOneAxis);
+}
+
+export function isGraphValidType(graph: ICODAPGraph): boolean {
+  return graph.plotType === "scatterPlot" || isUnivariateDotPlot(graph);
+}


### PR DESCRIPTION
[DAVAI-13](https://concord-consortium.atlassian.net/browse/DAVAI-13?atlOrigin=eyJpIjoiZDc0NDEzYTU0MGRkNDMzN2FkNDViMjFmNjRiNTA4NTEiLCJwIjoiaiJ9)

Implements the following support for sonifying univariate dot plots:

- Bin the dots into 10 evenly spaced bins and counts the values in each bin
- Create a tone that transitions from one count to the next with the count setting the pitch of the tone

Note: CODAP does not currently support updating a graph to use bins via the API, so we just figure out the bins in the plugin, and animate the line across the graph as usual. If you do bin the graph via the component itself in CODAP, the bins match up pretty neatly with the tones.


[DAVAI-13]: https://concord-consortium.atlassian.net/browse/DAVAI-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ