### PR TITLE
feat: add deployment link to Jira (START-1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,6 @@ jobs:
       - build_test
       - cypress
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ github.ref_type == 'branch' && 'branches' || 'versions' }}
-      url: https://codap3.concord.org/branch/main/index.html?sample=mammals&di=https://codap3.concord.org/davai-plugin/${{ steps.s3-deploy.outputs.deployPath }}/
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -89,6 +86,8 @@ jobs:
           prefix: davai-plugin
           awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
           awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          deployRunUrl: https://codap3.concord.org/branch/main/index.html?sample=mammals&di=https://codap3.concord.org/davai-plugin/__deployPath__/index.html
           # Parameters to GHActions have to be strings, so a regular yaml array cannot
           # be used. Instead the `|` turns the following lines into a string
           topBranches: |


### PR DESCRIPTION
[START-1](https://concord-consortium.atlassian.net/browse/START-1)

Remove `environment` from `ci.yml` and add `githubToken` and `deployRunUrl`. This will allow the new version of `s3-deploy-action` to create a GitHub Deployment and set its `log_url` property, which will allow Jira to add a deployment link to associated Jira issues.

[START-1]: https://concord-consortium.atlassian.net/browse/START-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ