### PR TITLE
fix: Should be able to choose from all assistants (DAVAI-41)

### DIFF
--- a/src/components/developer-options.test.tsx
+++ b/src/components/developer-options.test.tsx
@@ -1,11 +1,26 @@
 import "openai/shims/node";
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
+import { types } from "mobx-state-tree";
 
 import { DeveloperOptionsComponent } from "./developer-options";
-import { AssistantModel } from "../models/assistant-model";
+import { AssistantModelType } from "../models/assistant-model";
 import { ChatTranscriptModel } from "../models/chat-transcript-model";
 import { mockAppConfig } from "../test-utils/mock-app-config";
+
+const MockAssistantModel = types
+  .model("MockAssistantModel", {
+    apiConnection: types.frozen(),
+    assistant: types.maybe(types.frozen()),
+    assistantId: types.string,
+    assistantList: types.optional(types.map(types.string), {}),
+    thread: types.maybe(types.frozen()),
+    transcriptStore: ChatTranscriptModel
+  })
+  .actions((self) => ({
+    createThread: jest.fn(),
+    deleteThread: jest.fn()
+  }));
 
 const mockTranscriptStore = ChatTranscriptModel.create({
   messages: [
@@ -18,7 +33,7 @@ const mockTranscriptStore = ChatTranscriptModel.create({
   ],
 });
 
-const mockAssistantStore = AssistantModel.create({
+const mockAssistantStore = MockAssistantModel.create({
   apiConnection: {
     apiKey: "abc123",
     dangerouslyAllowBrowser: true
@@ -30,7 +45,7 @@ const mockAssistantStore = AssistantModel.create({
   },
   thread: {},
   transcriptStore: mockTranscriptStore,
-});
+}) as unknown as AssistantModelType;
 
 jest.mock("../models/app-config-model", () => ({
   AppConfigModel: {

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -468,6 +468,10 @@ export const AssistantModel = types
           await self.handleMessageSubmit(allMsgs);
         }
       });
+
+      if (self.apiConnection) {
+        self.fetchAssistantsList();
+      }
     }
   }));
 


### PR DESCRIPTION
[DAVAI-41](https://concord-consortium.atlassian.net/browse/DAVAI-41)

This fixes a bug that made "Mock Assistant" the only available option in the "Select an Assistant" menu. At some point after we moved the request for a list of available assistants from `DeveloperOptionsComponent` to `AssistantModel`, we stopped making the request. So the `assistantList` property on `AssistantModel` wasn't being defined.

[DAVAI-41]: https://concord-consortium.atlassian.net/browse/DAVAI-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ