### PR TITLE
feat: link data to graph image for description (DAVAI-38)

### DIFF
--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -321,17 +321,12 @@ export const AssistantModel = types
           const yAttrData = yield getAttributeData(graphID, graph.yAttributeID);
           const y2AttrData = yield getAttributeData(graphID, graph.y2AttributeID);
 
-          // Combine y-axis data if we have a second y-axis
-          const combinedYAxisData = y2AttrData.attributeData 
-            ? { attributeData: [yAttrData.attributeData, y2AttrData.attributeData] }
-            : yAttrData;
-
           const graphAttrData: IGraphAttrData = {
             legend: { attributeData: legendAttrData },
             rightSplit: { attributeData: rightAttrData },
             topSplit: { attributeData: topAttrData },
             xAxis: { attributeData: xAttrData },
-            yAxis: { attributeData: combinedYAxisData },
+            yAxis: { attributeData: yAttrData },
             y2Axis: { attributeData: y2AttrData }
           };
 


### PR DESCRIPTION
[DAVAI-38](https://concord-consortium.atlassian.net/browse/DAVAI-38)

When an graph image snapshot is sent to the LLM, we now include data about the attributes on the graph for additional context. This helps the LLM describe the graph image better, especially for large datasets where points on a graph may overlap.

[DAVAI-38]: https://concord-consortium.atlassian.net/browse/DAVAI-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ