### PR TITLE
DAVAI-37: Smooth sonification values in univariate dot plot

### DIFF
--- a/__mocks__/tone.js
+++ b/__mocks__/tone.js
@@ -10,24 +10,28 @@ module.exports = {
     connect: jest.fn(),
     triggerAttackRelease: jest.fn(),
     toDestination: jest.fn(),
+    dispose: jest.fn(),
   })),
   Oscillator: jest.fn(() => ({
     connect: jest.fn(),
     rampTo: jest.fn(),
     start: jest.fn(),
     stop: jest.fn(),
+    dispose: jest.fn(),
+    sync: jest.fn(() => ({
+      start: jest.fn(),
+      stop: jest.fn(),
+    })),
   })),
   Panner: jest.fn(() => ({
     toDestination: jest.fn(),
+    dispose: jest.fn(),
   })),
-  Gain: jest.fn(() => ({
-    connect: jest.fn(),
-    rampTo: jest.fn(),
-    gain: jest.fn(() => ({
-      rampTo: jest.fn()
-    })),
+  Part: jest.fn(() => ({
+    start: jest.fn(),
+    stop: jest.fn(),
+    dispose: jest.fn(),
   })),
   start: jest.fn(),
   stop: jest.fn(),
-
 };

--- a/src/components/graph-sonification-utils.ts
+++ b/src/components/graph-sonification-utils.ts
@@ -1,9 +1,13 @@
 import { codapInterface } from "@concord-consortium/codap-plugin-api";
 
 export const mapPitchFractionToFrequency = (pitchFraction: number) => {
-  const lowerFreqBound = 220;
-  const upperFreqBound = 880;
-  return lowerFreqBound + pitchFraction * (upperFreqBound - lowerFreqBound);
+  if (pitchFraction === 0) {
+    return 0;
+  } else {
+    const lowerFreqBound = 220;
+    const upperFreqBound = 880;
+    return lowerFreqBound + pitchFraction * (upperFreqBound - lowerFreqBound);
+  }
 };
 
 export const mapValueToStereoPan = (value: number, min: number, max: number) => {
@@ -13,6 +17,37 @@ export const mapValueToStereoPan = (value: number, min: number, max: number) => 
   const normalizedPosition = distanceFromMin / totalRange;
   return normalizedPosition * 2 - 1;
 };
+
+export const interpolateBins = (bins: number[], stepCount: number): number[] => {
+  const result: number[] = [];
+  const n = bins.length;
+  if (n === 0) return result;
+
+  for (let i = 0; i < stepCount; i++) {
+    // find the position in the bins array
+    const pos = (i / stepCount) * (n - 1);
+    const left = Math.floor(pos);
+    const right = Math.ceil(pos);
+    const t = pos - left;
+    // linear interpolation between bins[left] and bins[right]
+    const value = (1 - t) * bins[left] + t * bins[right];
+    result.push(value);
+  }
+  return result;
+};
+
+export const createRoiAdornment = async (graphId: string) => {
+  await codapInterface.sendRequest({
+    action: "create",
+    resource: `component[${graphId}].adornment`,
+    values: {
+      type: "Region of Interest",
+      primary: { "position": "0%", "extent": "0.05%" }, // 0.05% consistently approximates 1 pixel
+      secondary: { "position": "0%", "extent": "100%" }
+    }
+  });
+};
+
 
 export const updateRoiAdornment = async (graphName: string, fraction: number) => {
   await codapInterface.sendRequest({

--- a/src/components/graph-sonification-utils.ts
+++ b/src/components/graph-sonification-utils.ts
@@ -36,7 +36,7 @@ export const interpolateBins = (bins: number[], stepCount: number): number[] => 
   return result;
 };
 
-export const createRoiAdornment = async (graphId: string) => {
+export const createRoiAdornment = async (graphId: number) => {
   await codapInterface.sendRequest({
     action: "create",
     resource: `component[${graphId}].adornment`,
@@ -49,10 +49,10 @@ export const createRoiAdornment = async (graphId: string) => {
 };
 
 
-export const updateRoiAdornment = async (graphName: string, fraction: number) => {
+export const updateRoiAdornment = async (graphId: number, fraction: number) => {
   await codapInterface.sendRequest({
     action: "update",
-    resource: `component[${graphName}].adornment`,
+    resource: `component[${graphId}].adornment`,
     values: {
       type: "Region of Interest",
       primary: { "position": `${fraction * 100}%`, "extent": "0.05%" } // 0.05% consistently approximates 1 pixel
@@ -60,7 +60,7 @@ export const updateRoiAdornment = async (graphName: string, fraction: number) =>
   });
 };
 
-export const removeRoiAdornment = async (graphId: string) => {
+export const removeRoiAdornment = async (graphId: number) => {
   await codapInterface.sendRequest({
     action: "delete",
     resource: `component[${graphId}].adornment`,

--- a/src/components/graph-sonification.tsx
+++ b/src/components/graph-sonification.tsx
@@ -131,6 +131,7 @@ export const GraphSonification = observer(({sonificationStore}: IProps) => {
     if (playState.ended || isAtBeginning) {
       setPlayState({ playing: true, ended: false, position: 0 });
       updateRoiAdornment(selectedGraphID, 0);
+      scheduleTones();
       restartTransport();
       animateSonification();
       return;

--- a/src/components/graph-sonification.tsx
+++ b/src/components/graph-sonification.tsx
@@ -31,9 +31,9 @@ export const GraphSonification = observer(({sonificationStore}: IProps) => {
   const isLoopingRef = useRef(false);
   const isNewGraph = useRef(false);
 
-  const {osc, gain, pan, poly, part, resetUnivariateSources, cancelAndResetTransport, restartTransport} = useTone();
+  const {osc, pan, poly, part, resetUnivariateSources, cancelAndResetTransport, restartTransport} = useTone();
   const { scheduleTones } = useSonificationScheduler({ selectedGraph, binValues, pitchFractions,
-    timeFractions, timeValues, primaryBounds, osc, pan, gain, poly, part, durationRef });
+    timeFractions, timeValues, primaryBounds, osc, pan, poly, part, durationRef });
 
   const [showError, setShowError] = useState(false);
   const [speed, setSpeed] = useState(1);

--- a/src/hooks/use-sonification-scheduler.ts
+++ b/src/hooks/use-sonification-scheduler.ts
@@ -13,14 +13,13 @@ type Props = {
   primaryBounds: any;
   osc: React.MutableRefObject<Tone.Oscillator | null>;
   pan: React.MutableRefObject<Tone.Panner | null>;
-  gain: React.MutableRefObject<Tone.Gain | null>;
   poly: React.MutableRefObject<Tone.PolySynth | null>;
   part: React.MutableRefObject<Tone.Part | null>;
   durationRef: React.MutableRefObject<number>;
 };
 
 export const useSonificationScheduler = ({ selectedGraph, binValues, pitchFractions, timeFractions, timeValues, primaryBounds,
-  osc, pan, gain, poly, part, durationRef}: Props) => {
+  osc, pan, poly, part, durationRef}: Props) => {
 
   const scheduleUnivariate = useCallback(() => {
     if (!binValues || !primaryBounds) return;
@@ -86,15 +85,15 @@ export const useSonificationScheduler = ({ selectedGraph, binValues, pitchFracti
 
     if (selectedGraph.plotType === "scatterPlot") {
       scheduleScatter();
-    } else if (isUnivariateDotPlot(selectedGraph) && gain.current) {
+    } else if (isUnivariateDotPlot(selectedGraph) && pan.current) {
       // create a new oscillator to use for univariate sonification
-      osc.current = new Tone.Oscillator(220, "sine").connect(gain.current);
+      osc.current = new Tone.Oscillator(220, "sine").connect(pan.current);
       // this syncs the oscillator to the transport, so that when we call transport.start or
       // transport.stop, the oscillator will start/stop accordingly
       osc.current.sync().start(0).stop(durationRef.current);
       scheduleUnivariate();
     }
-  }, [osc, part, selectedGraph, gain, scheduleScatter, durationRef, scheduleUnivariate]);
+  }, [osc, part, selectedGraph, pan, scheduleScatter, durationRef, scheduleUnivariate]);
 
   return {
     scheduleTones

--- a/src/hooks/use-sonification-scheduler.ts
+++ b/src/hooks/use-sonification-scheduler.ts
@@ -3,14 +3,19 @@ import { useCallback } from "react";
 import * as Tone from "tone";
 import { interpolateBins, mapPitchFractionToFrequency, mapValueToStereoPan } from "../components/graph-sonification-utils";
 import { isUnivariateDotPlot } from "../utils/utils";
+import { ICODAPGraph } from "../types";
+import { IBinModel } from "../models/bin-model";
 
 type Props = {
-  selectedGraph: any;
-  binValues: any;
+  selectedGraph: ICODAPGraph | undefined;
+  binValues: IBinModel | undefined;
   pitchFractions: number[];
   timeFractions: number[];
   timeValues: number[];
-  primaryBounds: any;
+  primaryBounds: {
+    upperBound: number | undefined;
+    lowerBound: number | undefined;
+  };
   osc: React.MutableRefObject<Tone.Oscillator | null>;
   pan: React.MutableRefObject<Tone.Panner | null>;
   poly: React.MutableRefObject<Tone.PolySynth | null>;

--- a/src/hooks/use-sonification-scheduler.ts
+++ b/src/hooks/use-sonification-scheduler.ts
@@ -1,0 +1,102 @@
+// hooks/useSonificationScheduler.ts
+import { useCallback } from "react";
+import * as Tone from "tone";
+import { interpolateBins, mapPitchFractionToFrequency, mapValueToStereoPan } from "../components/graph-sonification-utils";
+import { isUnivariateDotPlot } from "../utils/utils";
+
+type Props = {
+  selectedGraph: any;
+  binValues: any;
+  pitchFractions: number[];
+  timeFractions: number[];
+  timeValues: number[];
+  primaryBounds: any;
+  osc: React.MutableRefObject<Tone.Oscillator | null>;
+  pan: React.MutableRefObject<Tone.Panner | null>;
+  gain: React.MutableRefObject<Tone.Gain | null>;
+  poly: React.MutableRefObject<Tone.PolySynth | null>;
+  part: React.MutableRefObject<Tone.Part | null>;
+  durationRef: React.MutableRefObject<number>;
+};
+
+export const useSonificationScheduler = ({ selectedGraph, binValues, pitchFractions, timeFractions, timeValues, primaryBounds,
+  osc, pan, gain, poly, part, durationRef}: Props) => {
+
+  const scheduleUnivariate = useCallback(() => {
+    if (!binValues || !primaryBounds) return;
+    const { bins, minBinEdge, maxBinEdge, binWidth } = binValues;
+    const maxCount = Math.max(...bins) || 1;
+    const stepCount = 1000;
+    const interval = durationRef.current / stepCount;
+    const smoothBinValues: number[] = interpolateBins(bins, stepCount);
+
+    const freqsToSchedule: [number, { freqValue: number; panValue: number }][] = smoothBinValues.map((count: number, i: number) => {
+      const offset = i * interval;
+      const countFraction = count / maxCount;
+      const freq = mapPitchFractionToFrequency(countFraction);
+      const binAvg = minBinEdge + ((i + 0.5) / stepCount) * binWidth;
+      const panVal = mapValueToStereoPan(binAvg, minBinEdge, maxBinEdge);
+      return [offset, { freqValue: freq, panValue: panVal }];
+    });
+
+    part.current = new Tone.Part((time, value) => {
+      const { freqValue, panValue } = value;
+      pan.current?.pan.linearRampToValueAtTime(panValue, time + interval);
+      osc.current?.frequency.linearRampToValueAtTime(freqValue, time + interval);
+    }, freqsToSchedule).start(0);
+  }, [binValues, primaryBounds, durationRef, osc, pan, part]);
+
+  const scheduleScatter = useCallback(() => {
+    if (!primaryBounds) return;
+    const { lowerBound: timeLowerBound, upperBound: timeUpperBound } = primaryBounds;
+    if (!timeLowerBound || !timeUpperBound) return;
+
+    const fractionGroups: Record<number, number[]> = {};
+    timeFractions.forEach((frac, i) => {
+      if (!fractionGroups[frac]) fractionGroups[frac] = [];
+      fractionGroups[frac].push(i);
+    });
+
+    const uniqueFractions = Object.keys(fractionGroups).map(parseFloat).sort((a, b) => a - b);
+
+    const scatterEvents: [number, { voices: { freqValue: number; panValue: number }[] }][] = uniqueFractions.map((fraction) => {
+      const offsetSeconds = fraction * durationRef.current;
+      const indices = fractionGroups[fraction];
+      const voices = indices.map(i => ({
+        freqValue: mapPitchFractionToFrequency(pitchFractions[i]),
+        panValue: mapValueToStereoPan(timeValues[i], timeLowerBound, timeUpperBound)
+      }));
+      return [offsetSeconds, { voices }];
+    });
+
+    part.current = new Tone.Part((time, note) => {
+      note.voices.forEach(({ freqValue, panValue }) => {
+        pan.current?.pan.setValueAtTime(panValue, time);
+        poly.current?.triggerAttackRelease(freqValue, "8n", time);
+      });
+    }, scatterEvents).start(0);
+  }, [primaryBounds, timeFractions, pitchFractions, timeValues, poly, pan, part, durationRef]);
+
+  const scheduleTones = useCallback(() => {
+    // dispose current oscillators and parts
+    osc.current?.dispose();
+    part.current?.dispose();
+
+    if (!selectedGraph) return;
+
+    if (selectedGraph.plotType === "scatterPlot") {
+      scheduleScatter();
+    } else if (isUnivariateDotPlot(selectedGraph) && gain.current) {
+      // create a new oscillator to use for univariate sonification
+      osc.current = new Tone.Oscillator(220, "sine").connect(gain.current);
+      // this syncs the oscillator to the transport, so that when we call transport.start or
+      // transport.stop, the oscillator will start/stop accordingly
+      osc.current.sync().start(0).stop(durationRef.current);
+      scheduleUnivariate();
+    }
+  }, [osc, part, selectedGraph, gain, scheduleScatter, durationRef, scheduleUnivariate]);
+
+  return {
+    scheduleTones
+  };
+};

--- a/src/hooks/use-tone.ts
+++ b/src/hooks/use-tone.ts
@@ -23,11 +23,9 @@ export function useTone() {
     };
   }, []);
 
-  const resetUnivariateSources = useCallback(() => {
+  const disposeUnivariateSources = useCallback(() => {
     osc.current?.dispose();
     part.current?.dispose();
-    osc.current =  new Tone.Oscillator();
-    part.current = new Tone.Part();
   }
   , []);
 
@@ -59,8 +57,7 @@ export function useTone() {
     pan,
     poly,
     part,
-    transport: Tone.getTransport(),
-    resetUnivariateSources,
+    disposeUnivariateSources,
     setTransportToStart,
     stopAndResetTransport,
     cancelAndResetTransport,

--- a/src/hooks/use-tone.ts
+++ b/src/hooks/use-tone.ts
@@ -3,7 +3,6 @@ import * as Tone from "tone";
 
 export function useTone() {
   const pan = useRef<Tone.Panner | null>(null);
-  const gain = useRef<Tone.Gain | null>(null);
   const osc = useRef<Tone.Oscillator | null>(null);
   const poly = useRef<Tone.PolySynth | null>(null);
   const part = useRef<Tone.Part | null>(null);
@@ -11,14 +10,12 @@ export function useTone() {
   useEffect(() => {
     // Setup audio graph
     pan.current = new Tone.Panner(0).toDestination();
-    gain.current = new Tone.Gain(1).connect(pan.current);
-    poly.current = new Tone.PolySynth().connect(gain.current);
+    poly.current = new Tone.PolySynth().connect(pan.current);
     osc.current = new Tone.Oscillator(); // we don't want to initialize it with a frequency yet
     part.current = new Tone.Part(); // we don't want to initialize it with any events yet
 
     return () => {
       Tone.getTransport().cancel();
-      gain.current?.dispose();
       osc.current?.dispose();
       pan.current?.dispose();
       part.current?.dispose();
@@ -59,7 +56,6 @@ export function useTone() {
 
   return {
     osc,
-    gain,
     pan,
     poly,
     part,

--- a/src/hooks/use-tone.ts
+++ b/src/hooks/use-tone.ts
@@ -1,0 +1,73 @@
+import { useRef, useEffect, useCallback } from "react";
+import * as Tone from "tone";
+
+export function useTone() {
+  const pan = useRef<Tone.Panner | null>(null);
+  const gain = useRef<Tone.Gain | null>(null);
+  const osc = useRef<Tone.Oscillator | null>(null);
+  const poly = useRef<Tone.PolySynth | null>(null);
+  const part = useRef<Tone.Part | null>(null);
+
+  useEffect(() => {
+    // Setup audio graph
+    pan.current = new Tone.Panner(0).toDestination();
+    gain.current = new Tone.Gain(1).connect(pan.current);
+    poly.current = new Tone.PolySynth().connect(gain.current);
+    osc.current = new Tone.Oscillator(); // we don't want to initialize it with a frequency yet
+    part.current = new Tone.Part(); // we don't want to initialize it with any events yet
+
+    return () => {
+      Tone.getTransport().cancel();
+      gain.current?.dispose();
+      osc.current?.dispose();
+      pan.current?.dispose();
+      part.current?.dispose();
+      poly.current?.dispose();
+    };
+  }, []);
+
+  const resetUnivariateSources = useCallback(() => {
+    osc.current?.dispose();
+    part.current?.dispose();
+    osc.current =  new Tone.Oscillator();
+    part.current = new Tone.Part();
+  }
+  , []);
+
+  const setTransportToStart = useCallback(() => {
+    Tone.getTransport().position = 0;
+    Tone.getTransport().seconds = 0;
+  }, []);
+
+  const stopAndResetTransport = useCallback(() => {
+    if (Tone.getTransport().state === "started") {
+      Tone.getTransport().stop();
+    }
+    setTransportToStart();
+  }, [setTransportToStart]);
+
+  const restartTransport = useCallback(() => {
+    stopAndResetTransport();
+    Tone.getTransport().start();
+  }, [stopAndResetTransport]);
+
+  const cancelAndResetTransport = useCallback(() => {
+    Tone.getTransport().stop();
+    Tone.getTransport().cancel();
+    setTransportToStart();
+  }, [setTransportToStart]);
+
+  return {
+    osc,
+    gain,
+    pan,
+    poly,
+    part,
+    transport: Tone.getTransport(),
+    resetUnivariateSources,
+    setTransportToStart,
+    stopAndResetTransport,
+    cancelAndResetTransport,
+    restartTransport
+  };
+}

--- a/src/models/graph-sonification-model.ts
+++ b/src/models/graph-sonification-model.ts
@@ -151,7 +151,7 @@ export const GraphSonificationModel = types
         }),
         ({ selectedGraphID, validGraphIDs }) => {
           if (selectedGraphID !== undefined && !validGraphIDs.includes(selectedGraphID)) {
-            removeRoiAdornment(`${selectedGraphID}`);
+            removeRoiAdornment(selectedGraphID);
             self.removeSelectedGraphID();
           }
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,3 +133,15 @@ export interface ICODAPGraph {
   yLowerBound?: number;
   yUpperBound?: number;
 }
+
+export type UnivariateNote = {
+  freqValue: number;
+  panValue: number;
+};
+
+export type ScatterNote = {
+  voices: {
+    freqValue: number;
+    panValue: number;
+  }[];
+};


### PR DESCRIPTION
[DAVAI-37](https://concord-consortium.atlassian.net/browse/DAVAI-37?atlOrigin=eyJpIjoiYTQxZGM0ZGUzNWM0NDQwZjk5ZTI3YWEzOWZlNjA2MWMiLCJwIjoiaiJ9)

This PR smooths out the transitions between bins by interpolating bin frequencies, when the graph sonification is of a univariate dot plot.

It also introduces some other changes due to issues I was noticing with the univariate playback. I think currently on the main branch, looping doesn't work with univariate dot plots.

One of the issues causing this was how we were previously using oscillator.start and oscillator.stop at different points in the code, rather than just depending on the Transport for starting, pausing, and stopping. This was because I didn't realize you could sync the oscillator to the transport. Now, by calling oscillator.current.sync, the oscillator's start is synced to the Transport's start.

Also, instead of calling scheduleOnce, the code now creates a new Tone.Part instance, which has a beginning synced to the Transport's start time, and an end synced to the durationRef. This is helpful because now, if we are looping, we no longer need to reschedule the tones at the end of a loop -- the transport just starts from the beginning, which the part is synced to, so everything plays as it should.

One thing is I'm not 100% sure this Part model will be compatible with when we want to step through the graphs in the future. But it seems like it actually might be more compatible than what we had before. But that is something to consider, although it feels a little bit beyond what I can figure out right now.

Also I moved some of the Tone.js code into two different hooks, to break up the component a bit, as it was feeling a bit unwieldy to me.

One thing that I've been thinking about, which is outside of the scope of this work but came up because of a comment left by Copilot, is that in the future we most likely will want to keep track of which graphs have ROI adornments created, and the positions of those adornments. I can imagine that when users are stepping through graphs, we might not want to re-set the position of an existing ROI every time a new graph is selected, and that if a previously selected graph is selected again, we'll want to know about its existing ROI position. Again, outside of the scope of this work, but just a note that I think somewhere down the line we'll have to incorporate that information in our models.

[DAVAI-37]: https://concord-consortium.atlassian.net/browse/DAVAI-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ