### PR TITLE
feat: support for LangSmith env vars (DAVAI-59)

### DIFF
--- a/sam-server/env.example
+++ b/sam-server/env.example
@@ -11,5 +11,11 @@ DAVAI_API_SECRET=your-secret-here
 OPENAI_API_KEY=your-openai-key
 GOOGLE_API_KEY=your-google-key
 
+# LangSmith Configuration
+LANGSMITH_TRACING=true
+LANGSMITH_ENDPOINT=https://api.smith.langchain.com
+LANGSMITH_API_KEY=abc123
+LANGSMITH_PROJECT=davai
+
 # Environment
 ENVIRONMENT=dev

--- a/sam-server/package-lock.json
+++ b/sam-server/package-lock.json
@@ -17,6 +17,7 @@
         "@langchain/langgraph-checkpoint": "^0.1.0",
         "@langchain/langgraph-checkpoint-postgres": "^0.1.1",
         "@langchain/openai": "^0.5.11",
+        "langsmith": "^0.3.63",
         "nanoid": "^5.0.9",
         "pg": "^8.16.3",
         "zod": "^3.25.48"
@@ -6779,9 +6780,10 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.3.56",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.56.tgz",
-      "integrity": "sha512-LLAppYZ6EWodnWSqgf/526ONtfb4Z1qR3QnF1+mYgOAr7aPOs9KNvxZMoCsg4oTXfxgf/+UJQ3Q1roTQEKJUag==",
+      "version": "0.3.63",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.63.tgz",
+      "integrity": "sha512-GrioB7LOUksKIYsdYbBUwyD3ezy+OAQ5eu5vebytMsX3wT0xfW4rbM+vHqCY7RgZwUYLR/RlpuC18pdO+NqugA==",
+      "license": "MIT",
       "dependencies": {
         "@types/uuid": "^10.0.0",
         "chalk": "^4.1.2",

--- a/sam-server/package.json
+++ b/sam-server/package.json
@@ -23,6 +23,7 @@
     "@langchain/langgraph-checkpoint": "^0.1.0",
     "@langchain/langgraph-checkpoint-postgres": "^0.1.1",
     "@langchain/openai": "^0.5.11",
+    "langsmith": "^0.3.63",
     "nanoid": "^5.0.9",
     "pg": "^8.16.3",
     "zod": "^3.25.48"

--- a/sam-server/src/utils/env-utils.ts
+++ b/sam-server/src/utils/env-utils.ts
@@ -68,3 +68,4 @@ export const getApiKey = async (provider: string, opts?: { region?: string }): P
 // Convenience wrappers, if you like:
 export const getOpenAIKey = () => getApiKey("OPENAI");
 export const getGoogleKey = () => getApiKey("GOOGLE");
+export const getLangSmithKey = () => getApiKey("LANGSMITH");

--- a/sam-server/template.yaml
+++ b/sam-server/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
-Description: Davai Plugin Server - AWS SAM Version
+Description: DAVAI Plugin Server - AWS SAM Version
 
 Parameters:
   Environment:
@@ -172,7 +172,7 @@ Resources:
   DBSubnetGroup:
     Type: AWS::RDS::DBSubnetGroup
     Properties:
-      DBSubnetGroupDescription: Subnet group for Davai PostgreSQL
+      DBSubnetGroupDescription: Subnet group for DAVAI PostgreSQL
       SubnetIds:
         - !Ref PrivateSubnet1
         - !Ref PrivateSubnet2
@@ -231,22 +231,29 @@ Resources:
     Type: AWS::SecretsManager::Secret
     Properties:
       Name: !Sub "${Environment}-davai-api-secret"
-      Description: Secret for Davai API authentication
+      Description: Secret for DAVAI API authentication
       SecretString: !Sub '{"secret": "your-api-secret-here"}'
 
   OpenAIApiKey:
     Type: AWS::SecretsManager::Secret
     Properties:
       Name: !Sub "${Environment}-openai-api-key"
-      Description: OpenAI API key for Davai server
+      Description: OpenAI API key for DAVAI server
       SecretString: !Sub '{"key": "your-openai-key-here"}'
 
   GoogleApiKey:
     Type: AWS::SecretsManager::Secret
     Properties:
       Name: !Sub "${Environment}-google-api-key"
-      Description: Google API key for Davai server
+      Description: Google API key for DAVAI server
       SecretString: !Sub '{"key": "your-google-key-here"}'
+
+  LangSmithApiKey:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "${Environment}-langsmith-api-key"
+      Description: LangSmith API key for DAVAI server
+      SecretString: !Sub '{"key": "your-langsmith-key-here"}'
 
   # Status Handler Lambda
   StatusHandlerFunction:
@@ -364,6 +371,10 @@ Resources:
           POSTGRES_CONNECTION_STRING: !Sub "postgresql://${DBUsername}:${DBPassword}@${PostgreSQLDB.Endpoint.Address}:${PostgreSQLDB.Endpoint.Port}/postgres"
           OPENAI_API_KEY: !Ref OpenAIApiKey
           GOOGLE_API_KEY: !Ref GoogleApiKey
+          LANGSMITH_TRACING: "true"
+          LANGSMITH_ENDPOINT: "https://api.smith.langchain.com"
+          LANGSMITH_PROJECT: "davai"
+          LANGSMITH_API_KEY: !Ref LangSmithApiKey
       VpcConfig:
         SecurityGroupIds:
           - !Ref LambdaSecurityGroup
@@ -383,6 +394,7 @@ Resources:
                 - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${Environment}-davai-api-secret-*
                 - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${Environment}-openai-api-key-*
                 - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${Environment}-google-api-key-*
+                - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${Environment}-langsmith-api-key-*
       Timeout: 300
       MemorySize: 512
 


### PR DESCRIPTION
[DAVAI-59](https://concord-consortium.atlassian.net/browse/DAVAI-59)

Adds support LangSmith environment variables. When these environment variables are set (and `LANGSMITH_TRACING` is `true`), LangChain will automatically send data related to DAVAI usage to the related LangSmith account.

[DAVAI-59]: https://concord-consortium.atlassian.net/browse/DAVAI-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ