### PR TITLE
fix: Don't highlight play button when clicked (DAVAI-103)

### DIFF
--- a/src/components/graph-sonification.scss
+++ b/src/components/graph-sonification.scss
@@ -59,9 +59,9 @@
         };
       }
 
-      // Ensures the focus ring appears when focus is set programmatically
-      // via .focus() (e.g. keyboard shortcut).
-      &:focus {
+      // Shows the focus ring only when focus was set via keyboard shortcut,
+      // not on mouse click. The class is added programmatically and removed on blur.
+      &.keyboard-focused:focus {
         outline: auto Highlight; // Firefox
         outline: auto -webkit-focus-ring-color; // Chrome, Safari, Edge
       }

--- a/src/components/graph-sonification.tsx
+++ b/src/components/graph-sonification.tsx
@@ -36,6 +36,7 @@ export const GraphSonification = observer(() => {
   const playPauseButtonRef = useRef<HTMLButtonElement>(null);
 
   const [showError, setShowError] = useState(false);
+  const [keyboardFocused, setKeyboardFocused] = useState(false);
 
   const selectedGraphID = selectedGraph?.id;
 
@@ -108,6 +109,7 @@ export const GraphSonification = observer(() => {
     return shortcutsService.registerShortcutHandler("sonifyGraph", (event) => {
       event.preventDefault();
 
+      setKeyboardFocused(true);
       playPauseButtonRef.current?.focus();
       playPauseButtonRef.current?.scrollIntoView({behavior: "smooth", block: "nearest"});
     }, { focus: true });
@@ -166,9 +168,10 @@ export const GraphSonification = observer(() => {
       <div className="sonification-buttons">
         <button
           ref={playPauseButtonRef}
-          className="play"
+          className={`play${keyboardFocused ? " keyboard-focused" : ""}`}
           data-testid="playback-button"
           onClick={handlePlayPause}
+          onBlur={() => setKeyboardFocused(false)}
           aria-disabled={!selectedGraphID}
         >
           { isPlaying ? <PauseIcon /> : <PlayIcon /> }


### PR DESCRIPTION
[DAVAI-103](https://concord-consortium.atlassian.net/browse/DAVAI-103)

A prior change was intended to apply a focus ring to the sonification Play button when focus was placed on the button by the sonification keyboard shortcut (Control+Shift+>). That led to all sonification buttons getting the focus ring on mouse click as well. Since that isn't desired, the changes here ensure that the focus ring is only shown on keyboard focus. (Note that using `:focus-visible` instead of `:focus` wouldn't solve the problem.)

[DAVAI-103]: https://concord-consortium.atlassian.net/browse/DAVAI-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ