### PR TITLE
Migrate S3 deploys to OIDC (no more long-lived AWS keys)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,10 @@ jobs:
       - build_test
       - cypress
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -118,7 +122,11 @@ jobs:
           # skip installing cypress since it isn't needed for just building
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
-      - uses: concord-consortium/s3-deploy-action@v1
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/davai-plugin
+          aws-region: us-east-1
+      - uses: concord-consortium/s3-deploy-action@4909d521b8957b6f8015fc08a3609c95974bc1ca # v1
         id: s3-deploy
         env:
           REACT_APP_OPENAI_BASE_URL: ${{ secrets.REACT_APP_OPENAI_BASE_URL }}
@@ -127,8 +135,6 @@ jobs:
         with:
           bucket: models-resources
           prefix: davai-plugin
-          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           deployRunUrl: https://codap3.concord.org/branch/main/index.html?sample=mammals&di=https://codap3.concord.org/davai-plugin/__deployPath__/index.html
           # Parameters to GHActions have to be strings, so a regular yaml array cannot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,15 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/davai-plugin
+          aws-region: us-east-1
       - run: >
           aws s3 cp
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ github.event.inputs.version }}/${{ env.SRC_FILE }}
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/${{ env.DEST_FILE }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,11 @@
+# Deployment
+
+The frontend in this repo is deployed to S3 by the `s3-deploy` job in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml). It uses the [s3-deploy-action](https://github.com/concord-consortium/s3-deploy-action), which uploads the built `dist/` contents to `s3://models-resources/davai-plugin/` (under a `branch/` or `version/` subfolder depending on the trigger).
+
+Releases — promoting a built version's `index-top.html` to top-level `index.html` — are handled by the `release` workflow in [`.github/workflows/release.yml`](../.github/workflows/release.yml), triggered manually via **Actions → Release → Run workflow** with a git tag.
+
+## AWS Access
+
+The GitHub Actions in this project are allowed to update files in S3 using OIDC. An IAM role has been created in AWS with a trust policy that allows GitHub Actions in this specific repository to assume the role. The role has a `RepoName` tag and a managed policy that uses this tag to give the role's users permission to update files in `models-resources/davai-plugin`.
+
+For one-time setup details (creating the IAM role, OIDC provider, shared policy), see the canonical setup doc in [starter-projects/doc/deploy-setup.md](https://github.com/concord-consortium/starter-projects/blob/main/doc/deploy-setup.md).


### PR DESCRIPTION
## Summary

Replace the static `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` secrets used by the GitHub Actions deploy workflows with short-lived credentials obtained via OpenID Connect (OIDC). Deploys now assume the per-repo IAM role `arn:aws:iam::612297603577:role/davai-plugin`, which carries a `RepoName=davai-plugin` tag and the shared `S3-deploy-by-role-tag` managed policy scoping S3 writes to `models-resources/davai-plugin/*`.

## Changes

- **`.github/workflows/ci.yml`** (`s3-deploy` job): added `permissions: id-token: write`, added `aws-actions/configure-aws-credentials` step (SHA-pinned), SHA-pinned `concord-consortium/s3-deploy-action`, removed `awsAccessKeyId` / `awsSecretAccessKey` inputs.
- **`.github/workflows/release.yml`** (`release` job — also migrated, in addition to what ocean-explorer's PR covered): added `permissions:` block, added `configure-aws-credentials` step before `aws s3 cp`, removed inline `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_DEFAULT_REGION` env vars.
- **`docs/deploy.md`** (new): brief overview of the deploy workflows and an "AWS Access" section explaining the OIDC role; links to the canonical setup doc in `starter-projects`.

## References

- Pattern precedent: concord-consortium/ocean-explorer#1
- Canonical setup doc: [starter-projects/doc/deploy-setup.md](https://github.com/concord-consortium/starter-projects/blob/main/doc/deploy-setup.md)
- IAM role created via `scripts/create-deploy-role.sh davai-plugin` (script kept local; canonical copy lives in starter-projects)

## Test plan

### Before merging — verify from this PR's CI run

- [x] `s3-deploy` job on this PR is green
- [x] In its log, `aws-actions/configure-aws-credentials` step shows successful OIDC role assumption (something like "Assuming role with OIDC...Authenticated as arn:aws:iam:...")
- [x] `s3-deploy-action` step uploaded files (look for `[CHANGED]` / `[NEW]` lines, or a deploy URL printed at the end)
- [x] The branch deploy URL works in a browser: `https://models-resources.concord.org/davai-plugin/branch/oidc-authentication/index.html` (or whatever path the action reports in its summary)
- [x] The CODAP wrapper URL also loads: `https://codap3.concord.org/branch/main/index.html?sample=mammals&di=https://codap3.concord.org/davai-plugin/branch/oidc-authentication/index.html`

### After merging — verify main + release

- [ ] Push-to-`main` (via merge) triggers `ci.yml`; `s3-deploy` job succeeds and top-level/main URLs update
- [ ] Trigger **Actions → Release → Run workflow** with a known version tag (or defer until the next legitimate release); confirm `aws s3 cp` succeeds and `index.html` at the top level updates