### PR TITLE
Add response-time entry to the debug log

### DIFF
--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -345,14 +345,17 @@ export const AssistantModel = types
           }
         }
       } catch (err) {
+        // Log before the error message so the timing row sits above it, like the
+        // other terminal branches. Disarms itself, so the finally call is a no-op.
+        logResponseTime();
         console.error("Failed to handle message submit:", err);
         self.addDbgMsg("Failed to handle message submit", formatJsonMessage(err));
       } finally {
         self.isLoadingResponse = false;
         self.setShowLoadingIndicator(false);
         self.currentMessageId = null;
-        // Backstop: covers the catch path and a success that produced no chat
-        // output (tool-only end). No-op if an inline call already logged.
+        // Backstop for a success that produced no chat output (tool-only end).
+        // No-op if an inline call already logged (including the catch path).
         logResponseTime();
       }
     });

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -2,7 +2,7 @@ import { types, flow, Instance, getRoot, onSnapshot } from "mobx-state-tree";
 import { nanoid } from "nanoid";
 import { codapInterface } from "@concord-consortium/codap-plugin-api";
 import { DAVAI_SPEAKER, DEBUG_SPEAKER } from "../constants";
-import { formatJsonMessage } from "../utils/utils";
+import { formatJsonMessage, formatElapsedTime } from "../utils/utils";
 import { getDataContexts, getGraphAttrData, getGraphByID, getTrimmedGraphDetails } from "../utils/codap-api-utils";
 import { isGraphSonifiable } from "../utils/graph-sonification-utils";
 import { ChatTranscriptModel } from "./chat-transcript-model";
@@ -240,6 +240,17 @@ export const AssistantModel = types
     });
 
     const handleMessageSubmit = flow(function* (messageText: string) {
+      // Time from when real processing begins to when a terminal outcome is
+      // reached. logResponseTime posts exactly one debug entry (it disarms
+      // itself), and is called just before each terminal output so the entry
+      // appears directly above the response in the transcript.
+      let startTime: number | undefined;
+      const logResponseTime = () => {
+        if (startTime === undefined) return;
+        const elapsed = formatElapsedTime(performance.now() - startTime);
+        self.addDbgMsg(`Response time: ${elapsed}`, elapsed);
+        startTime = undefined;
+      };
       try {
         self.setShowLoadingIndicator(true);
         if (self.isCancelling || self.isResetting) {
@@ -247,6 +258,7 @@ export const AssistantModel = types
           self.addDbgMsg(description, `User message added to queue: ${messageText}`);
           self.messageQueue.push(messageText);
         } else {
+          startTime = performance.now();
           self.isLoadingResponse = true;
 
           // Generate a unique message ID for this request. This lets us cancel the message if needed.
@@ -290,9 +302,11 @@ export const AssistantModel = types
               data = output;
               break;
             } else if (status === "cancelled") {
+              logResponseTime();
               self.addDbgMsg("Job was cancelled on the server", messageId);
               return;
             } else if (status === "error") {
+              logResponseTime();
               self.addDbgMsg("Server error processing message", output?.error || "Unknown error");
               self.addDavaiMsg("Sorry, I ran into an error processing that request.");
               return;
@@ -304,6 +318,7 @@ export const AssistantModel = types
           }
 
           if (!data) {
+            logResponseTime();
             self.addDbgMsg("Polling expired before response received", messageId);
             return;
           }
@@ -325,6 +340,7 @@ export const AssistantModel = types
 
           // Once we're out of the tool call chain, handle the final response.
           if (data?.response) {
+            logResponseTime();
             self.addDavaiMsg(data.response);
           }
         }
@@ -335,6 +351,9 @@ export const AssistantModel = types
         self.isLoadingResponse = false;
         self.setShowLoadingIndicator(false);
         self.currentMessageId = null;
+        // Backstop: covers the catch path and a success that produced no chat
+        // output (tool-only end). No-op if an inline call already logged.
+        logResponseTime();
       }
     });
 

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,0 +1,19 @@
+import { formatElapsedTime } from "./utils";
+
+describe("formatElapsedTime", () => {
+  it("formats whole and fractional seconds to 2 decimals with a unit", () => {
+    expect(formatElapsedTime(4234)).toBe("4.23 s");
+  });
+
+  it("formats sub-second durations with a leading zero", () => {
+    expect(formatElapsedTime(850)).toBe("0.85 s");
+  });
+
+  it("formats zero", () => {
+    expect(formatElapsedTime(0)).toBe("0.00 s");
+  });
+
+  it("formats large durations", () => {
+    expect(formatElapsedTime(60000)).toBe("60.00 s");
+  });
+});

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -9,6 +9,12 @@ export const formatJsonMessage = (json: any) => {
   return JSON.stringify(json, null, 2);
 };
 
+// Format an elapsed duration in milliseconds as seconds with 2 decimal places,
+// e.g. 4234 -> "4.23 s". Used for the response-time debug log entry.
+export const formatElapsedTime = (ms: number): string => {
+  return `${(ms / 1000).toFixed(2)} s`;
+};
+
 export const playSound = (note: string) => {
   const synth = new Tone.Synth().toDestination();
   synth.triggerAttackRelease(note, "8n");


### PR DESCRIPTION
## Summary
- Adds a `Response time: X.XX s` entry to the DAVAI debug log, measuring wall-clock time from when a user's prompt begins processing to when a terminal outcome is reached.
- New pure helper `formatElapsedTime(ms)` (unit-tested) formats the duration as seconds with 2 decimals.
- In `handleMessageSubmit`, a `performance.now()` timer logs **exactly one** entry per processed request via a small `logResponseTime()` closure — called immediately before each terminal output (success, server error, cancel, 30s polling timeout, and the catch path) so the entry appears directly above the outcome in the transcript, with a `finally` backstop for tool-only completions.
- The formatted value is placed in the always-visible debug label so it's readable at a glance.
- **Not timed:** mock mode (hardcoded 2s delay). **Queued messages:** when a submission arrives while DAVAI is busy it is queued, and that *queuing* call is not timed — but the later call that processes the flushed queue *is* timed (measured from when processing starts, so it excludes the prior queue wait). This is intentional; the queue wait is really "waiting for the previous response," which gets its own timed entry.

## Test Plan
- [x] `npm test` — 212/212 pass (includes 4 new `formatElapsedTime` tests)
- [x] `npm run lint` clean; `npm run build:webpack` compiles
- [x] Manual (CODAP, local): a real model shows a `Response time:` row directly above DAVAI's reply; Mock mode shows none

🤖 Generated with [Claude Code](https://claude.com/claude-code)