### PR TITLE
DAVAI-104: capture chat transcript (CSV + image zip) and customizable shortcuts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
           bucket: models-resources
           prefix: davai-plugin
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          deployRunUrl: https://codap3.concord.org/branch/main/index.html?sample=mammals&di=https://codap3.concord.org/davai-plugin/__deployPath__/index.html
+          deployRunUrl: https://codap.concord.org/app/index.html?sample=mammals&di=https://codap.concord.org/davai-plugin/__deployPath__/index.html
           # Parameters to GHActions have to be strings, so a regular yaml array cannot
           # be used. Instead the `|` turns the following lines into a string
           topBranches: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ The client never talks to an LLM provider directly — it posts to the server, w
 
 ### Client development
 ```bash
-npm start                    # webpack-dev-server on port 8080 (HTTP); proxies CODAP from codap3.concord.org
+npm start                    # webpack-dev-server on port 8080 (HTTP); proxies CODAP from codap.concord.org
 npm run start:secure         # Same, but HTTPS (uses certs in ~/.localhost-ssl/)
 ```
 
@@ -103,14 +103,14 @@ See [README.md](README.md#environments-and-the-llm-server) and [docs/deploy.md](
 
 ## Testing the plugin in CODAP
 
-`npm start` serves the plugin on **http://localhost:8080** and proxies everything it doesn't serve to `codap3.concord.org` (`devServer.proxy` in `webpack.config.js`). That makes CODAP and the local plugin **same-origin**, sidestepping CODAP's https/mixed-content restriction:
-- CODAP (proxied): `http://localhost:8080/branch/main/`
+`npm start` serves the plugin on **http://localhost:8080** and proxies everything it doesn't serve to `codap.concord.org` (production CODAP, served at `/app/`; see `devServer.proxy` in `webpack.config.js`). That makes CODAP and the local plugin **same-origin**, sidestepping CODAP's https/mixed-content restriction:
+- CODAP (proxied): `http://localhost:8080/app/`
 - The plugin (served by webpack): `http://localhost:8080/`
 
 Load the plugin into CODAP with the `di` (data-interactive) URL param, all on the same origin:
 
 ```
-http://localhost:8080/branch/main/?di=http%3A%2F%2Flocalhost%3A8080%2F%3Fmode%3Ddevelopment
+http://localhost:8080/app/?di=http%3A%2F%2Flocalhost%3A8080%2F%3Fmode%3Ddevelopment
 ```
 
 (That `di` value is `http://localhost:8080/?mode=development`, URL-encoded so the nested query string survives.) Use `npm run start:secure` if you need the dev server over HTTPS instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@ The client never talks to an LLM provider directly — it posts to the server, w
 
 ### Client development
 ```bash
-npm start                    # webpack-dev-server on port 8081 (HTTP)
-npm run start:secure         # Dev server with HTTPS
+npm start                    # webpack-dev-server on port 8080 (HTTP); proxies CODAP from codap3.concord.org
+npm run start:secure         # Same, but HTTPS (uses certs in ~/.localhost-ssl/)
 ```
 
 ### Building
@@ -103,9 +103,17 @@ See [README.md](README.md#environments-and-the-llm-server) and [docs/deploy.md](
 
 ## Testing the plugin in CODAP
 
-CODAP forces `https`, so loading the local `http` plugin requires one of:
-1. Local CODAP at `http://127.0.0.1:8080/static/dg/en/cert/index.html?di=http://localhost:8081`
-2. Chrome with web security disabled: `open -na "Google Chrome" --args --disable-web-security --user-data-dir=/tmp`, then in CODAP **Options → Load web page** enter `http://localhost:8081/?mode=development`.
+`npm start` serves the plugin on **http://localhost:8080** and proxies everything it doesn't serve to `codap3.concord.org` (`devServer.proxy` in `webpack.config.js`). That makes CODAP and the local plugin **same-origin**, sidestepping CODAP's https/mixed-content restriction:
+- CODAP (proxied): `http://localhost:8080/branch/main/`
+- The plugin (served by webpack): `http://localhost:8080/`
+
+Load the plugin into CODAP with the `di` (data-interactive) URL param, all on the same origin:
+
+```
+http://localhost:8080/branch/main/?di=http%3A%2F%2Flocalhost%3A8080%2F%3Fmode%3Ddevelopment
+```
+
+(That `di` value is `http://localhost:8080/?mode=development`, URL-encoded so the nested query string survives.) Use `npm run start:secure` if you need the dev server over HTTPS instead.
 
 ## AI assistant settings (`/ai-assistant-settings`)
 Version-controlled copies of OpenAI-platform assistant instructions/functions. Sync the latest from platform.openai.com with `npm run sync:assistant-settings` before editing, then commit.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ To work on the client without any server or API keys, enable development mode (a
 
 ## Testing the plugin in CODAP
 
-CODAP forces `https`, which normally makes it awkward to load a plugin from a local `http` dev server. The dev server solves this with a proxy: `npm start` serves the plugin on **http://localhost:8080** and forwards anything it doesn't serve to `codap3.concord.org` (see `devServer.proxy` in `webpack.config.js`). That puts CODAP and the local plugin on the **same origin**, so there is no mixed-content problem:
+CODAP forces `https`, which normally makes it awkward to load a plugin from a local `http` dev server. The dev server solves this with a proxy: `npm start` serves the plugin on **http://localhost:8080** and forwards anything it doesn't serve to `codap.concord.org` (production CODAP, served at `/app/`; see `devServer.proxy` in `webpack.config.js`). That puts CODAP and the local plugin on the **same origin**, so there is no mixed-content problem:
 
-- CODAP (proxied from codap3.concord.org): `http://localhost:8080/branch/main/`
+- CODAP (proxied from codap.concord.org): `http://localhost:8080/app/`
 - The plugin (served by webpack): `http://localhost:8080/`
 
 ### Recommended: load via the `di` URL param
@@ -27,10 +27,10 @@ CODAP forces `https`, which normally makes it awkward to load a plugin from a lo
 Start the dev server (`npm start`) and open CODAP with the plugin embedded via the `di` (data-interactive) parameter — all on `localhost:8080`:
 
 ```
-http://localhost:8080/branch/main/?di=http%3A%2F%2Flocalhost%3A8080%2F%3Fmode%3Ddevelopment
+http://localhost:8080/app/?di=http%3A%2F%2Flocalhost%3A8080%2F%3Fmode%3Ddevelopment
 ```
 
-The `di` value above is `http://localhost:8080/?mode=development`, URL-encoded so the nested query string (`?mode=development`, which enables the Developer Options panel and Mock LLM) survives. If CODAP doesn't auto-add the plugin, open `http://localhost:8080/branch/main/` and add the plugin URL `http://localhost:8080/?mode=development` from CODAP's plugin menu.
+The `di` value above is `http://localhost:8080/?mode=development`, URL-encoded so the nested query string (`?mode=development`, which enables the Developer Options panel and Mock LLM) survives. If CODAP doesn't auto-add the plugin, open `http://localhost:8080/app/` and add the plugin URL `http://localhost:8080/?mode=development` from CODAP's plugin menu.
 
 Run `npm run start:secure` instead if you need the dev server over HTTPS (it uses the certs in `~/.localhost-ssl/`).
 
@@ -43,7 +43,7 @@ If you need to point CODAP at a plugin URL that isn't covered by the proxy, you 
    ```
    open -na "Google Chrome" --args --disable-web-security --user-data-dir=/tmp
    ```
-3. In that window, open CODAP (e.g. `http://localhost:8080/branch/main/`) and a sample document.
+3. In that window, open CODAP (e.g. `http://localhost:8080/app/`) and a sample document.
 4. In CODAP, go to **Options** > **Load web page** and enter `http://localhost:8080/?mode=development`.
 
 ## Environments and the LLM server

--- a/README.md
+++ b/README.md
@@ -17,27 +17,34 @@ To work on the client without any server or API keys, enable development mode (a
 
 ## Testing the plugin in CODAP
 
-Currently there is no trivial way to load a plugin running on a local server with `http` into the online CODAP, which forces `https`.
+CODAP forces `https`, which normally makes it awkward to load a plugin from a local `http` dev server. The dev server solves this with a proxy: `npm start` serves the plugin on **http://localhost:8080** and forwards anything it doesn't serve to `codap3.concord.org` (see `devServer.proxy` in `webpack.config.js`). That puts CODAP and the local plugin on the **same origin**, so there is no mixed-content problem:
 
-### Method one
-One simple solution is to download the latest `build_[...].zip` file from https://codap.concord.org/releases/zips/, extract it to a folder and run it locally. If CODAP is running on port 8080, and this project is running by default on 8081, you can go to
+- CODAP (proxied from codap3.concord.org): `http://localhost:8080/branch/main/`
+- The plugin (served by webpack): `http://localhost:8080/`
 
-http://127.0.0.1:8080/static/dg/en/cert/index.html?di=http://localhost:8081
+### Recommended: load via the `di` URL param
 
-to see the plugin running in CODAP.
+Start the dev server (`npm start`) and open CODAP with the plugin embedded via the `di` (data-interactive) parameter — all on `localhost:8080`:
 
-### Method two
+```
+http://localhost:8080/branch/main/?di=http%3A%2F%2Flocalhost%3A8080%2F%3Fmode%3Ddevelopment
+```
 
-1. Start the DAVAI plugin by running `npm start` in this codebase.
-2. Open the CODAP repository, navigate to the `v3` directory, and run `npm start` to launch CODAP locally.
-3. Open a new Chrome window with web security disabled by running:
-  ```
-  open -na "Google Chrome" --args --disable-web-security --user-data-dir=/tmp
-  ```
-4. In this Chrome window, go to the local CODAP URL (e.g., `http://localhost:8080`) and open a sample file (such as "Mammals").
-5. In CODAP, go to **Options** > **Load web page**, and enter the local DAVAI plugin URL (for example, `http://localhost:8081/?mode=development`).
+The `di` value above is `http://localhost:8080/?mode=development`, URL-encoded so the nested query string (`?mode=development`, which enables the Developer Options panel and Mock LLM) survives. If CODAP doesn't auto-add the plugin, open `http://localhost:8080/branch/main/` and add the plugin URL `http://localhost:8080/?mode=development` from CODAP's plugin menu.
 
-This method allows you to test the plugin locally in CODAP, bypassing browser security restrictions that normally prevent loading local resources.
+Run `npm run start:secure` instead if you need the dev server over HTTPS (it uses the certs in `~/.localhost-ssl/`).
+
+### Fallback: Chrome with web security disabled
+
+If you need to point CODAP at a plugin URL that isn't covered by the proxy, you can bypass browser security:
+
+1. Start the DAVAI plugin with `npm start`.
+2. Open a Chrome window with web security disabled:
+   ```
+   open -na "Google Chrome" --args --disable-web-security --user-data-dir=/tmp
+   ```
+3. In that window, open CODAP (e.g. `http://localhost:8080/branch/main/`) and a sample document.
+4. In CODAP, go to **Options** > **Load web page** and enter `http://localhost:8080/?mode=development`.
 
 ## Environments and the LLM server
 

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -21,3 +21,15 @@
 
 // add code coverage support
 import "@cypress/code-coverage/support";
+
+// The plugin talks to CODAP through the CODAP plugin API (iframe-phone). These specs
+// load the plugin standalone, with no CODAP host, so codap-plugin-api requests time
+// out and call back with `undefined` — and the library then throws asynchronously
+// (e.g. selectSelf reading `result.success`). Those library-level errors are expected
+// here and unrelated to whether the app renders, so don't let them fail the spec.
+// Errors originating in our own code still fail the test.
+Cypress.on("uncaught:exception", (err) => {
+  const fromCodapComms = err.stack?.includes("codap-plugin-api") || err.stack?.includes("iframe-phone");
+  // Returning false tells Cypress to ignore the error; anything else lets it fail.
+  return !fromCodapComms;
+});

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,7 @@ Generated from source comments and MST runtime introspection. Do not edit manual
 | --------------------------------------- | -------- | ------------------------------------------- |
 | dimensions.height                       | number   | 680                                         |
 | dimensions.width                        | number   | 380                                         |
+| keyboardShortcuts.captureTranscript     | string   | "Control+Shift+Semicolon"                   |
 | keyboardShortcuts.focusChatInput        | string   | "Control+Shift+Slash"                       |
 | keyboardShortcuts.replayLastDavaiMessage | string   | "Control+Shift+Comma"                       |
 | keyboardShortcuts.sonifyGraph           | string   | "Control+Shift+Period"                      |
@@ -34,6 +35,10 @@ Height of the plugin in CODAP (in pixels).
 ## `dimensions.width`
 
 Width of the plugin in CODAP (in pixels).
+
+## `keyboardShortcuts.captureTranscript`
+
+The shortcut key combination to capture (copy + download) the chat transcript.
 
 ## `keyboardShortcuts.focusChatInput`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "deepmerge": "^4.3.1",
         "dotenv": "^16.4.5",
         "fast-deep-equal": "^3.1.3",
+        "fflate": "^0.8.3",
         "loess": "^1.3.5",
         "mobx": "^6.13.7",
         "mobx-react-lite": "^4.0.7",
@@ -9657,6 +9658,12 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "deepmerge": "^4.3.1",
     "dotenv": "^16.4.5",
     "fast-deep-equal": "^3.1.3",
+    "fflate": "^0.8.3",
     "loess": "^1.3.5",
     "mobx": "^6.13.7",
     "mobx-react-lite": "^4.0.7",

--- a/src/app-config.json
+++ b/src/app-config.json
@@ -2,7 +2,8 @@
   "keyboardShortcuts": {
     "focusChatInput": "Control+Shift+Slash",
     "replayLastDavaiMessage": "Control+Shift+Comma",
-    "sonifyGraph": "Control+Shift+Period"
+    "sonifyGraph": "Control+Shift+Period",
+    "captureTranscript": "Control+Shift+Semicolon"
   },
   "keyboardShortcutsEnabled": true,
   "playProcessingMessage": true,

--- a/src/components/chat-transcript.scss
+++ b/src/components/chat-transcript.scss
@@ -1,5 +1,16 @@
 @use "vars" as *;
 
+.chat-transcript__toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin: 0 0 5px;
+
+  button.capture-transcript {
+    font-size: .75rem;
+    cursor: pointer;
+  }
+}
+
 .chat-transcript {
   margin: 0;
   max-height: 250px;

--- a/src/components/chat-transcript.test.tsx
+++ b/src/components/chat-transcript.test.tsx
@@ -76,4 +76,47 @@ describe("test chat transcript component", () => {
 
     clickSpy.mockRestore();
   });
+
+  it("downloads a zip and references the image when the transcript contains a base64 image", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    const createObjectURL = jest.fn((_blob: Blob) => "blob:url");
+    (global.URL as any).createObjectURL = createObjectURL;
+    (global.URL as any).revokeObjectURL = jest.fn();
+    const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+
+    const transcriptWithImage = {
+      messages: [
+        {
+          messageContent: {
+            description: "Response from CODAP",
+            content: '{"exportDataUri":"data:image/png;base64,aGVsbG8="}',
+          },
+          speaker: "Debug Log",
+          timestamp: "2021-07-01T12:00:10Z",
+          id: "img-1",
+          plainTextContent: "",
+        },
+      ],
+    };
+
+    render(
+      <AppConfigProvider>
+        <ShortcutsServiceProvider>
+          <ChatTranscriptComponent chatTranscript={transcriptWithImage}/>
+        </ShortcutsServiceProvider>
+      </AppConfigProvider>
+    );
+
+    fireEvent.click(screen.getByTestId("capture-transcript-button"));
+
+    await waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(1));
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe("application/zip");
+    // The clipboard still gets the readable CSV with an images/ reference, not the base64.
+    expect(writeText.mock.calls[0][0]).toContain("images/image-001.png");
+    expect(writeText.mock.calls[0][0]).not.toContain("aGVsbG8=");
+
+    clickSpy.mockRestore();
+  });
 });

--- a/src/components/chat-transcript.test.tsx
+++ b/src/components/chat-transcript.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import { AppConfigProvider } from "../contexts/app-config-context";
 import { ChatTranscriptComponent } from "./chat-transcript";
@@ -49,5 +49,31 @@ describe("test chat transcript component", () => {
       const content = within(message).getByTestId("chat-message-content");
       expect(content).toHaveTextContent(chatTranscript.messages[index].messageContent.content);
     });
+  });
+
+  it("copies the transcript and downloads it when the capture button is clicked", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    (global.URL as any).createObjectURL = jest.fn(() => "blob:url");
+    (global.URL as any).revokeObjectURL = jest.fn();
+    const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+
+    render(
+      <AppConfigProvider>
+        <ShortcutsServiceProvider>
+          <ChatTranscriptComponent chatTranscript={chatTranscript}/>
+        </ShortcutsServiceProvider>
+      </AppConfigProvider>
+    );
+
+    fireEvent.click(screen.getByTestId("capture-transcript-button"));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    const copiedText = writeText.mock.calls[0][0] as string;
+    expect(copiedText).toContain("DAVAI Chat Transcript");
+    expect(copiedText).toContain("Hello. How can I help you today?");
+
+    clickSpy.mockRestore();
   });
 });

--- a/src/components/chat-transcript.test.tsx
+++ b/src/components/chat-transcript.test.tsx
@@ -71,7 +71,7 @@ describe("test chat transcript component", () => {
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
     expect(clickSpy).toHaveBeenCalledTimes(1);
     const copiedText = writeText.mock.calls[0][0] as string;
-    expect(copiedText).toContain("DAVAI Chat Transcript");
+    expect(copiedText).toContain('"timestamp","speaker","debug event","message"');
     expect(copiedText).toContain("Hello. How can I help you today?");
 
     clickSpy.mockRestore();

--- a/src/components/chat-transcript.tsx
+++ b/src/components/chat-transcript.tsx
@@ -7,9 +7,11 @@ import { useAppConfigContext } from "../contexts/app-config-context";
 import { useShortcutsService } from "../contexts/shortcuts-service-context";
 import { useAriaLive } from "../contexts/aria-live-context";
 import {
+  buildTranscriptCsv,
+  buildTranscriptZip,
   copyTextToClipboard,
+  downloadBlob,
   downloadTextFile,
-  formatTranscriptForCapture,
   getTranscriptFilename,
 } from "../utils/transcript-utils";
 
@@ -38,16 +40,26 @@ export const ChatTranscriptComponent = observer(({chatTranscript, isLoading}: IP
   }, [chatTranscript.messages.length, isLoading]);
 
   const handleCaptureTranscript = useCallback(async () => {
-    const text = formatTranscriptForCapture(chatTranscript.messages);
-    const filename = getTranscriptFilename(appConfig.llmId, new Date());
+    const { csv, images } = buildTranscriptCsv(chatTranscript.messages);
 
+    // The clipboard always gets the readable CSV (with images/ references).
     let copied = true;
     try {
-      await copyTextToClipboard(text);
+      await copyTextToClipboard(csv);
     } catch {
       copied = false;
     }
-    downloadTextFile(filename, text);
+
+    // Download a zip (CSV + extracted images) when images are present, else a plain CSV.
+    if (images.length > 0) {
+      const zipBytes = buildTranscriptZip({ csv, images });
+      downloadBlob(
+        getTranscriptFilename(appConfig.llmId, new Date(), "zip"),
+        new Blob([zipBytes], { type: "application/zip" })
+      );
+    } else {
+      downloadTextFile(getTranscriptFilename(appConfig.llmId, new Date(), "csv"), csv);
+    }
 
     setAriaLiveText(copied
       ? "Transcript copied to clipboard and downloaded."

--- a/src/components/chat-transcript.tsx
+++ b/src/components/chat-transcript.tsx
@@ -42,12 +42,7 @@ export const ChatTranscriptComponent = observer(({chatTranscript, isLoading}: IP
     const { csv, images } = buildTranscriptCsv(chatTranscript.messages);
 
     // The clipboard always gets the readable CSV (with images/ references).
-    let copied = true;
-    try {
-      await copyTextToClipboard(csv);
-    } catch {
-      copied = false;
-    }
+    const copied = await copyTextToClipboard(csv).then(() => true, () => false);
 
     // Download a zip (CSV + extracted images) when images are present, else a plain CSV.
     if (images.length > 0) {

--- a/src/components/chat-transcript.tsx
+++ b/src/components/chat-transcript.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useCallback } from "react";
 import { observer } from "mobx-react-lite";
 import { ChatTranscriptMessage } from "./chat-transcript-message";
 import { ChatTranscript, ChatMessage } from "../types";
@@ -6,6 +6,14 @@ import { LoadingMessage } from "./loading-message";
 import { useAppConfigContext } from "../contexts/app-config-context";
 import { useShortcutsService } from "../contexts/shortcuts-service-context";
 import { useAriaLive } from "../contexts/aria-live-context";
+import { timeStamp } from "../utils/utils";
+import {
+  copyTextToClipboard,
+  downloadTextFile,
+  formatTranscriptForCapture,
+  getLlmLabel,
+  getTranscriptFilename,
+} from "../utils/transcript-utils";
 
 import "./chat-transcript.scss";
 
@@ -15,7 +23,8 @@ interface IProps {
 }
 
 export const ChatTranscriptComponent = observer(({chatTranscript, isLoading}: IProps) => {
-  const { showDebugLog } = useAppConfigContext();
+  const appConfig = useAppConfigContext();
+  const { showDebugLog } = appConfig;
   const shortcutsService = useShortcutsService();
   const chatTranscriptRef = useRef<HTMLDivElement>(null);
   const { setAriaLiveText } = useAriaLive();
@@ -30,6 +39,33 @@ export const ChatTranscriptComponent = observer(({chatTranscript, isLoading}: IP
     }
   }, [chatTranscript.messages.length, isLoading]);
 
+  const handleCaptureTranscript = useCallback(async () => {
+    const text = formatTranscriptForCapture(chatTranscript.messages, {
+      capturedAt: timeStamp(),
+      llmLabel: getLlmLabel(appConfig.llmId),
+    });
+    const filename = getTranscriptFilename(appConfig.llmId, new Date());
+
+    let copied = true;
+    try {
+      await copyTextToClipboard(text);
+    } catch {
+      copied = false;
+    }
+    downloadTextFile(filename, text);
+
+    setAriaLiveText(copied
+      ? "Transcript copied to clipboard and downloaded."
+      : "Transcript downloaded. Could not copy to clipboard.");
+  }, [chatTranscript, appConfig, setAriaLiveText]);
+
+  useEffect(() => {
+    return shortcutsService.registerShortcutHandler("captureTranscript", (event) => {
+      event.preventDefault();
+      handleCaptureTranscript();
+    }, { focus: true });
+  }, [shortcutsService, handleCaptureTranscript]);
+
   useEffect(() => {
     // A shortcut to set the last message in the live aria region
     return shortcutsService.registerShortcutHandler("replayLastDavaiMessage", (event) => {
@@ -38,7 +74,7 @@ export const ChatTranscriptComponent = observer(({chatTranscript, isLoading}: IP
       // We toggle an invisible character to force the screen reader to read the same message again.
       // We tried to clear the live text, wait, and set it again, but that didn't work
       replayHiddenCharToggleRef.current = !replayHiddenCharToggleRef.current;
-      const suffix = replayHiddenCharToggleRef.current ? "\u200B" : "\u200C";
+      const suffix = replayHiddenCharToggleRef.current ? "​" : "‌";
       if (lastDavaiMessage) {
         setAriaLiveText(`Last Message: ${lastDavaiMessage.plainTextContent}${suffix}`);
       } else {
@@ -48,23 +84,41 @@ export const ChatTranscriptComponent = observer(({chatTranscript, isLoading}: IP
   }, [chatTranscript.messages, setAriaLiveText, shortcutsService]);
 
   return (
-    <div ref={chatTranscriptRef} id="chat-transcript" className="chat-transcript" data-testid="chat-transcript" role="group">
-      <h2 className="visually-hidden">Chat Transcript</h2>
-      <div
-        className="chat-transcript__messages"
-        data-testid="chat-transcript__messages"
-        role="list"
-      >
-        {chatTranscript.messages.map((message: ChatMessage) => {
-          return (
-            <ChatTranscriptMessage
-              key={`${message.id}`}
-              message={message}
-              showDebugLog={showDebugLog}
-            />
-          );
-        })}
-        {isLoading && <LoadingMessage/>}
+    <div
+      className="chat-transcript-wrapper"
+      data-testid="chat-transcript"
+      role="group"
+      aria-labelledby="chat-transcript-heading"
+    >
+      <h2 id="chat-transcript-heading" className="visually-hidden">Chat Transcript</h2>
+      <div className="chat-transcript__toolbar">
+        <button
+          type="button"
+          className="capture-transcript"
+          data-testid="capture-transcript-button"
+          aria-label="Capture transcript"
+          onClick={handleCaptureTranscript}
+        >
+          Capture Transcript
+        </button>
+      </div>
+      <div ref={chatTranscriptRef} id="chat-transcript" className="chat-transcript">
+        <div
+          className="chat-transcript__messages"
+          data-testid="chat-transcript__messages"
+          role="list"
+        >
+          {chatTranscript.messages.map((message: ChatMessage) => {
+            return (
+              <ChatTranscriptMessage
+                key={`${message.id}`}
+                message={message}
+                showDebugLog={showDebugLog}
+              />
+            );
+          })}
+          {isLoading && <LoadingMessage/>}
+        </div>
       </div>
     </div>
   );

--- a/src/components/chat-transcript.tsx
+++ b/src/components/chat-transcript.tsx
@@ -6,12 +6,10 @@ import { LoadingMessage } from "./loading-message";
 import { useAppConfigContext } from "../contexts/app-config-context";
 import { useShortcutsService } from "../contexts/shortcuts-service-context";
 import { useAriaLive } from "../contexts/aria-live-context";
-import { timeStamp } from "../utils/utils";
 import {
   copyTextToClipboard,
   downloadTextFile,
   formatTranscriptForCapture,
-  getLlmLabel,
   getTranscriptFilename,
 } from "../utils/transcript-utils";
 
@@ -40,10 +38,7 @@ export const ChatTranscriptComponent = observer(({chatTranscript, isLoading}: IP
   }, [chatTranscript.messages.length, isLoading]);
 
   const handleCaptureTranscript = useCallback(async () => {
-    const text = formatTranscriptForCapture(chatTranscript.messages, {
-      capturedAt: timeStamp(),
-      llmLabel: getLlmLabel(appConfig.llmId),
-    });
+    const text = formatTranscriptForCapture(chatTranscript.messages);
     const filename = getTranscriptFilename(appConfig.llmId, new Date());
 
     let copied = true;

--- a/src/components/chat-transcript.tsx
+++ b/src/components/chat-transcript.tsx
@@ -74,7 +74,7 @@ export const ChatTranscriptComponent = observer(({chatTranscript, isLoading}: IP
       // We toggle an invisible character to force the screen reader to read the same message again.
       // We tried to clear the live text, wait, and set it again, but that didn't work
       replayHiddenCharToggleRef.current = !replayHiddenCharToggleRef.current;
-      const suffix = replayHiddenCharToggleRef.current ? "​" : "‌";
+      const suffix = replayHiddenCharToggleRef.current ? "\u200B" : "\u200C";
       if (lastDavaiMessage) {
         setAriaLiveText(`Last Message: ${lastDavaiMessage.plainTextContent}${suffix}`);
       } else {

--- a/src/components/chat-transcript.tsx
+++ b/src/components/chat-transcript.tsx
@@ -11,7 +11,6 @@ import {
   buildTranscriptZip,
   copyTextToClipboard,
   downloadBlob,
-  downloadTextFile,
   getTranscriptFilename,
 } from "../utils/transcript-utils";
 
@@ -58,7 +57,10 @@ export const ChatTranscriptComponent = observer(({chatTranscript, isLoading}: IP
         new Blob([zipBytes], { type: "application/zip" })
       );
     } else {
-      downloadTextFile(getTranscriptFilename(appConfig.llmId, new Date(), "csv"), csv);
+      downloadBlob(
+        getTranscriptFilename(appConfig.llmId, new Date(), "csv"),
+        new Blob([csv], { type: "text/csv;charset=utf-8" })
+      );
     }
 
     setAriaLiveText(copied

--- a/src/components/keyboard-shortcut-controls.scss
+++ b/src/components/keyboard-shortcut-controls.scss
@@ -15,7 +15,9 @@
 
     &[disabled] {
       cursor: not-allowed;
-      opacity: 0.75;
+      // 0.9 (not lower) keeps any still-mounted confirmation/error message text
+      // above the WCAG AA contrast threshold while a row is disabled.
+      opacity: 0.9;
 
       button, input, label {
         cursor: not-allowed;

--- a/src/components/keyboard-shortcut-controls.test.tsx
+++ b/src/components/keyboard-shortcut-controls.test.tsx
@@ -56,6 +56,21 @@ describe("test keyboard shortcut controls component", () => {
     expect(screen.queryByTestId("custom-keyboard-shortcut-sonifyGraph-confirmation")).toBeNull();
   });
 
+  it("dismiss button is type=button and removes the confirmation without resubmitting", () => {
+    render(<WrapperComponent />);
+    const form = screen.getByTestId("custom-keyboard-shortcut-focusChatInput-form");
+    fireEvent.change(within(form).getByTestId("custom-keyboard-shortcut-focusChatInput"), {target: {value: customShortcut}});
+    fireEvent.click(within(form).getByTestId("custom-keyboard-shortcut-focusChatInput-submit"));
+
+    const dismiss = screen.getByTestId("custom-keyboard-shortcut-focusChatInput-confirmation-dismiss");
+    // A bare <button> in a <form> defaults to type=submit, which would re-fire the
+    // form instead of dismissing. It must be type=button.
+    expect(dismiss).toHaveAttribute("type", "button");
+
+    fireEvent.click(dismiss);
+    expect(screen.queryByTestId("custom-keyboard-shortcut-focusChatInput-confirmation")).toBeNull();
+  });
+
   it("shows an error message when a shortcut input is emptied", () => {
     render(<WrapperComponent />);
     const form = screen.getByTestId("custom-keyboard-shortcut-sonifyGraph-form");

--- a/src/components/keyboard-shortcut-controls.test.tsx
+++ b/src/components/keyboard-shortcut-controls.test.tsx
@@ -4,22 +4,24 @@ import { cleanup, fireEvent, render, screen, within } from "@testing-library/rea
 import { AppConfigProvider } from "../contexts/app-config-context";
 import { KeyboardShortcutControls } from "./keyboard-shortcut-controls";
 
-
 describe("test keyboard shortcut controls component", () => {
-  const defaultShortcut = "Control+Shift+Slash";
   const customShortcut = "Control+b";
+  const shortcutRows = [
+    { key: "focusChatInput", description: "Focus the chat input", value: "Control+Shift+Slash" },
+    { key: "replayLastDavaiMessage", description: "Replay the last DAVAI message", value: "Control+Shift+Comma" },
+    { key: "sonifyGraph", description: "Play the graph sonification", value: "Control+Shift+Period" },
+    { key: "captureTranscript", description: "Capture the chat transcript", value: "Control+Shift+Semicolon" },
+  ];
 
   afterEach(cleanup);
 
-  const WrapperComponent = () => {
-    return (
-      <AppConfigProvider>
-        <KeyboardShortcutControls/>
-      </AppConfigProvider>
-    );
-  };
+  const WrapperComponent = () => (
+    <AppConfigProvider>
+      <KeyboardShortcutControls/>
+    </AppConfigProvider>
+  );
 
-  it("renders a button for disabling/enabling the keyboard shortcut", () => {
+  it("renders a button for disabling/enabling the keyboard shortcuts", () => {
     render(<WrapperComponent />);
     const button = screen.getByTestId("keyboard-shortcut-toggle");
     expect(button).toHaveTextContent("Disable Shortcut");
@@ -29,38 +31,41 @@ describe("test keyboard shortcut controls component", () => {
     expect(button).toHaveTextContent("Disable Shortcut");
   });
 
-  it("renders a form for customizing the keyboard shortcut", async () => {
+  it("renders a labeled customize form for every shortcut", () => {
     render(<WrapperComponent />);
-    const form = screen.getByTestId("custom-keyboard-shortcut-form");
-    const input = within(form).getByTestId("custom-keyboard-shortcut");
-    expect(input).not.toHaveAttribute("aria-describedby");
-    expect(screen.queryByTestId("custom-keyboard-shortcut-confirmation")).toBeNull();
-    const submitButton = within(form).getByTestId("custom-keyboard-shortcut-submit");
-    expect(input).toHaveValue(defaultShortcut);
-    fireEvent.change(input, {target: {value: customShortcut}});
-    fireEvent.click(submitButton);
-    expect(input).toHaveValue(customShortcut);
-    expect(input).toHaveAttribute("aria-describedby", "custom-keyboard-shortcut-confirmation");
-    expect(screen.getByTestId("custom-keyboard-shortcut-confirmation")).toBeInTheDocument();
-    const confirmationMsg = screen.getByTestId("custom-keyboard-shortcut-confirmation").textContent;
-    expect(confirmationMsg).toContain(`Keyboard shortcut changed to ${customShortcut}`);
-    const dismissButton = screen.getByTestId("custom-keyboard-shortcut-confirmation-dismiss");
-    expect(dismissButton).toHaveTextContent("Dismiss this message.");
+    shortcutRows.forEach(({ key, description, value }) => {
+      const form = screen.getByTestId(`custom-keyboard-shortcut-${key}-form`);
+      expect(within(form).getByText(`${description}:`)).toBeInTheDocument();
+      expect(within(form).getByTestId(`custom-keyboard-shortcut-${key}`)).toHaveValue(value);
+    });
   });
 
-  it("shows an error message if the custom keyboard shortcut input is empty", () => {
+  it("customizes a single shortcut and shows that row's confirmation", () => {
     render(<WrapperComponent />);
-    const form = screen.getByTestId("custom-keyboard-shortcut-form");
-    const input = within(form).getByTestId("custom-keyboard-shortcut");
-    expect(input).toHaveAttribute("aria-invalid", "false");
-    expect(input).not.toHaveAttribute("aria-describedby");
-    expect(screen.queryByTestId("custom-keyboard-shortcut-error")).toBeNull();
+    const form = screen.getByTestId("custom-keyboard-shortcut-focusChatInput-form");
+    const input = within(form).getByTestId("custom-keyboard-shortcut-focusChatInput");
+    fireEvent.change(input, {target: {value: customShortcut}});
+    fireEvent.click(within(form).getByTestId("custom-keyboard-shortcut-focusChatInput-submit"));
+
+    expect(input).toHaveValue(customShortcut);
+    expect(input).toHaveAttribute("aria-describedby", "custom-keyboard-shortcut-focusChatInput-confirmation");
+    const confirmation = screen.getByTestId("custom-keyboard-shortcut-focusChatInput-confirmation");
+    expect(confirmation).toHaveTextContent(`Focus the chat input shortcut changed to ${customShortcut}`);
+
+    // other rows are unaffected
+    expect(screen.queryByTestId("custom-keyboard-shortcut-sonifyGraph-confirmation")).toBeNull();
+  });
+
+  it("shows an error message when a shortcut input is emptied", () => {
+    render(<WrapperComponent />);
+    const form = screen.getByTestId("custom-keyboard-shortcut-sonifyGraph-form");
+    const input = within(form).getByTestId("custom-keyboard-shortcut-sonifyGraph");
     fireEvent.change(input, {target: {value: ""}});
-    const submitButton = within(form).getByTestId("custom-keyboard-shortcut-submit");
-    fireEvent.click(submitButton);
+    fireEvent.click(within(form).getByTestId("custom-keyboard-shortcut-sonifyGraph-submit"));
+
     expect(input).toHaveAttribute("aria-invalid", "true");
-    expect(input).toHaveAttribute("aria-describedby", "custom-keyboard-shortcut-error");
-    expect(screen.getByTestId("custom-keyboard-shortcut-error")).toBeInTheDocument();
-    expect(screen.getByTestId("custom-keyboard-shortcut-error")).toHaveTextContent("Please enter a value for the keyboard shortcut.");
+    expect(input).toHaveAttribute("aria-describedby", "custom-keyboard-shortcut-sonifyGraph-error");
+    expect(screen.getByTestId("custom-keyboard-shortcut-sonifyGraph-error"))
+      .toHaveTextContent("Please enter a value for the keyboard shortcut.");
   });
 });

--- a/src/components/keyboard-shortcut-controls.tsx
+++ b/src/components/keyboard-shortcut-controls.tsx
@@ -2,42 +2,44 @@ import React, { FormEvent, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { ErrorMessage } from "./error-message";
 import { useAppConfigContext } from "../contexts/app-config-context";
+import { AppConfigKeyboardShortcutKeys } from "../models/app-config-model";
 
 import "./keyboard-shortcut-controls.scss";
 
+const KEYBOARD_SHORTCUT_OPTIONS: { key: AppConfigKeyboardShortcutKeys; description: string }[] = [
+  { key: "focusChatInput", description: "Focus the chat input" },
+  { key: "replayLastDavaiMessage", description: "Replay the last DAVAI message" },
+  { key: "sonifyGraph", description: "Play the graph sonification" },
+  { key: "captureTranscript", description: "Capture the chat transcript" },
+];
+
 export const KeyboardShortcutControls = observer(function KeyboardShortcutControls() {
   const appConfig = useAppConfigContext();
-  const { keyboardShortcutsEnabled, keyboardShortcuts: { focusChatInput } } = appConfig;
+  const { keyboardShortcutsEnabled, keyboardShortcuts } = appConfig;
   const toggleButtonLabel = keyboardShortcutsEnabled ? "Disable Shortcut" : "Enable Shortcut";
-  const [showError, setShowError] = useState(false);
-  const [showConfirmation, setShowConfirmation] = useState(false);
+  const [confirmedKey, setConfirmedKey] = useState<AppConfigKeyboardShortcutKeys | null>(null);
+  const [erroredKey, setErroredKey] = useState<AppConfigKeyboardShortcutKeys | null>(null);
 
   const handleToggleShortcut = () => {
     appConfig.toggleOption("keyboardShortcutsEnabled");
   };
 
-  const handleCustomizeShortcut = (event: FormEvent) => {
+  const handleCustomizeShortcut = (shortcutKey: AppConfigKeyboardShortcutKeys) => (event: FormEvent) => {
     if (!keyboardShortcutsEnabled) return;
     event.preventDefault();
-    const form = event.target as HTMLInputElement;
+    const form = event.target as HTMLFormElement;
     const shortcut = form.querySelector("input")?.value.trim();
     if (shortcut) {
       appConfig.update(() => {
-        appConfig.keyboardShortcuts.focusChatInput = shortcut;
+        appConfig.keyboardShortcuts[shortcutKey] = shortcut;
       });
-      setShowError(false);
-      setShowConfirmation(true);
+      setErroredKey(null);
+      setConfirmedKey(shortcutKey);
     } else {
-      setShowError(true);
-      setShowConfirmation(false);
+      setConfirmedKey(null);
+      setErroredKey(shortcutKey);
     }
   };
-
-  const customShortcutInputDescribedBy = showConfirmation
-    ? "custom-keyboard-shortcut-confirmation"
-    : showError
-      ? "custom-keyboard-shortcut-error"
-      : undefined;
 
   return (
     <div
@@ -53,38 +55,55 @@ export const KeyboardShortcutControls = observer(function KeyboardShortcutContro
             {toggleButtonLabel}
           </button>
         </div>
-        <form data-testid="custom-keyboard-shortcut-form" onSubmit={handleCustomizeShortcut}>
-          <fieldset aria-disabled={!keyboardShortcutsEnabled}>
-            <label htmlFor="custom-keyboard-shortcut">Customize Shortcut:</label>
-            <input
-              aria-describedby={customShortcutInputDescribedBy}
-              aria-invalid={showError}
-              data-testid="custom-keyboard-shortcut"
-              defaultValue={focusChatInput}
-              id="custom-keyboard-shortcut"
-              type="text"
-            />
-            <button data-testid="custom-keyboard-shortcut-submit" type="submit">Customize</button>
-            {showConfirmation &&
-              <div
-                aria-live="polite"
-                className="confirmation-message"
-                data-testid="custom-keyboard-shortcut-confirmation"
-                id="custom-keyboard-shortcut-confirmation"
-                role="status"
-              >
-                Keyboard shortcut changed to {focusChatInput}
-                <button
-                  className="dismiss"
-                  data-testid="custom-keyboard-shortcut-confirmation-dismiss"
-                  onClick={() => setShowConfirmation(false)}>
-                    <span className="visually-hidden">Dismiss this message.</span>
-                </button>
-              </div>
-            }
-            { showError && <ErrorMessage slug="custom-keyboard-shortcut" message="Please enter a value for the keyboard shortcut." /> }
-          </fieldset>
-        </form>
+        {KEYBOARD_SHORTCUT_OPTIONS.map(({ key, description }) => {
+          const inputId = `custom-keyboard-shortcut-${key}`;
+          const confirmationId = `${inputId}-confirmation`;
+          const showConfirmation = confirmedKey === key;
+          const showError = erroredKey === key;
+          const describedBy = showConfirmation
+            ? confirmationId
+            : showError
+              ? `${inputId}-error`
+              : undefined;
+          return (
+            <form
+              key={key}
+              data-testid={`${inputId}-form`}
+              onSubmit={handleCustomizeShortcut(key)}
+            >
+              <fieldset aria-disabled={!keyboardShortcutsEnabled}>
+                <label htmlFor={inputId}>{description}:</label>
+                <input
+                  aria-describedby={describedBy}
+                  aria-invalid={showError}
+                  data-testid={inputId}
+                  defaultValue={keyboardShortcuts[key]}
+                  id={inputId}
+                  type="text"
+                />
+                <button data-testid={`${inputId}-submit`} type="submit">Customize</button>
+                {showConfirmation &&
+                  <div
+                    aria-live="polite"
+                    className="confirmation-message"
+                    data-testid={confirmationId}
+                    id={confirmationId}
+                    role="status"
+                  >
+                    {description} shortcut changed to {keyboardShortcuts[key]}
+                    <button
+                      className="dismiss"
+                      data-testid={`${confirmationId}-dismiss`}
+                      onClick={() => setConfirmedKey(null)}>
+                        <span className="visually-hidden">Dismiss this message.</span>
+                    </button>
+                  </div>
+                }
+                { showError && <ErrorMessage slug={inputId} message="Please enter a value for the keyboard shortcut." /> }
+              </fieldset>
+            </form>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/keyboard-shortcut-controls.tsx
+++ b/src/components/keyboard-shortcut-controls.tsx
@@ -25,8 +25,8 @@ export const KeyboardShortcutControls = observer(function KeyboardShortcutContro
   };
 
   const handleCustomizeShortcut = (shortcutKey: AppConfigKeyboardShortcutKeys) => (event: FormEvent) => {
-    if (!keyboardShortcutsEnabled) return;
     event.preventDefault();
+    if (!keyboardShortcutsEnabled) return;
     const form = event.target as HTMLFormElement;
     const shortcut = form.querySelector("input")?.value.trim();
     if (shortcut) {

--- a/src/components/keyboard-shortcut-controls.tsx
+++ b/src/components/keyboard-shortcut-controls.tsx
@@ -71,7 +71,7 @@ export const KeyboardShortcutControls = observer(function KeyboardShortcutContro
               data-testid={`${inputId}-form`}
               onSubmit={handleCustomizeShortcut(key)}
             >
-              <fieldset aria-disabled={!keyboardShortcutsEnabled}>
+              <fieldset disabled={!keyboardShortcutsEnabled}>
                 <label htmlFor={inputId}>{description}:</label>
                 <input
                   aria-describedby={describedBy}

--- a/src/components/keyboard-shortcut-controls.tsx
+++ b/src/components/keyboard-shortcut-controls.tsx
@@ -51,7 +51,7 @@ export const KeyboardShortcutControls = observer(function KeyboardShortcutContro
       <h3 id="keyboard-shortcuts-heading">Keyboard Shortcuts</h3>
       <div className="options-list-1">
         <div className="user-option">
-          <button onClick={handleToggleShortcut} data-testid="keyboard-shortcut-toggle">
+          <button type="button" onClick={handleToggleShortcut} data-testid="keyboard-shortcut-toggle">
             {toggleButtonLabel}
           </button>
         </div>
@@ -92,6 +92,7 @@ export const KeyboardShortcutControls = observer(function KeyboardShortcutContro
                   >
                     {description} shortcut changed to {keyboardShortcuts[key]}
                     <button
+                      type="button"
                       className="dismiss"
                       data-testid={`${confirmationId}-dismiss`}
                       onClick={() => setConfirmedKey(null)}>

--- a/src/components/vars.scss
+++ b/src/components/vars.scss
@@ -9,5 +9,7 @@ $medium-gray: #030303;
 $medium-gray-2: #949494;
 $dark-gray: #222;
 
-$confirmation-color: #093;
-$error-color: #f00;
+// Darkened from #093 / #f00 so 12px message text meets WCAG 2.1 AA contrast
+// (4.5:1) on the white panel: #007a29 ≈ 5.5:1, #d40000 ≈ 5.1:1.
+$confirmation-color: #007a29;
+$error-color: #d40000;

--- a/src/models/app-config-model.test.ts
+++ b/src/models/app-config-model.test.ts
@@ -1,0 +1,9 @@
+import { AppConfigModel, AppConfigModelSnapshot } from "./app-config-model";
+import appConfigJson from "../app-config.json";
+
+describe("AppConfigModel keyboard shortcuts", () => {
+  it("includes the captureTranscript shortcut from app-config.json", () => {
+    const appConfig = AppConfigModel.create(appConfigJson as AppConfigModelSnapshot);
+    expect(appConfig.keyboardShortcuts.captureTranscript).toBe("Control+Shift+Semicolon");
+  });
+});

--- a/src/models/app-config-model.ts
+++ b/src/models/app-config-model.ts
@@ -132,6 +132,10 @@ export const AppConfigModel = types.model("AppConfigModel", {
      * The shortcut key combination to play the graph sonification. This is in tinykeys format.
      */
     sonifyGraph: types.string,
+    /**
+     * The shortcut key combination to capture (copy + download) the chat transcript.
+     */
+    captureTranscript: types.string,
   }),
   /**
    * Whether keyboard shortcuts are enabled. If false, keyboard shortcuts will be ignored.

--- a/src/test-utils/mock-app-config.ts
+++ b/src/test-utils/mock-app-config.ts
@@ -5,7 +5,8 @@ export const mockAppConfig: AppConfigModelSnapshot = {
   keyboardShortcuts: {
     focusChatInput: "Control+Shift+Slash",
     replayLastDavaiMessage: "Control+Shift+Comma",
-    sonifyGraph: "Control+Shift+Period"
+    sonifyGraph: "Control+Shift+Period",
+    captureTranscript: "Control+Shift+Semicolon"
   },
   keyboardShortcutsEnabled: true,
   playProcessingMessage: true,

--- a/src/utils/transcript-utils.test.ts
+++ b/src/utils/transcript-utils.test.ts
@@ -1,6 +1,6 @@
 import { strFromU8, unzipSync } from "fflate";
 import { ChatMessage } from "../types";
-import { buildTranscriptCsv, buildTranscriptZip, copyTextToClipboard, downloadTextFile, getTranscriptFilename } from "./transcript-utils";
+import { buildTranscriptCsv, buildTranscriptZip, copyTextToClipboard, downloadBlob, getTranscriptFilename } from "./transcript-utils";
 
 const imageDataUri = "data:image/png;base64,aGVsbG8=";
 const debugWithImage: ChatMessage = {
@@ -148,9 +148,9 @@ describe("getTranscriptFilename", () => {
   });
 });
 
-describe("downloadTextFile", () => {
+describe("downloadBlob", () => {
   it("creates an object URL, clicks a download anchor, and revokes the URL", () => {
-    const createObjectURL = jest.fn(() => "blob:url");
+    const createObjectURL = jest.fn((_blob: Blob) => "blob:url");
     const revokeObjectURL = jest.fn();
     (global.URL as any).createObjectURL = createObjectURL;
     (global.URL as any).revokeObjectURL = revokeObjectURL;
@@ -164,10 +164,11 @@ describe("downloadTextFile", () => {
     });
     const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
 
-    downloadTextFile("my-file.txt", "hello");
+    downloadBlob("my-file.csv", new Blob(["hello"], { type: "text/csv;charset=utf-8" }));
 
     expect(createObjectURL).toHaveBeenCalledTimes(1);
-    expect(anchor?.download).toBe("my-file.txt");
+    expect(createObjectURL.mock.calls[0][0].type).toBe("text/csv;charset=utf-8");
+    expect(anchor?.download).toBe("my-file.csv");
     expect(clickSpy).toHaveBeenCalledTimes(1);
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:url");
 

--- a/src/utils/transcript-utils.test.ts
+++ b/src/utils/transcript-utils.test.ts
@@ -1,5 +1,5 @@
 import { ChatMessage } from "../types";
-import { formatTranscriptForCapture, getLlmLabel, getTranscriptFilename } from "./transcript-utils";
+import { copyTextToClipboard, downloadTextFile, formatTranscriptForCapture, getLlmLabel, getTranscriptFilename } from "./transcript-utils";
 
 const messages: ChatMessage[] = [
   {
@@ -81,8 +81,6 @@ describe("getTranscriptFilename", () => {
     expect(name).toBe("davai-transcript-2026-06-23-unknown-llm.txt");
   });
 });
-
-import { copyTextToClipboard, downloadTextFile } from "./transcript-utils";
 
 describe("downloadTextFile", () => {
   it("creates an object URL, clicks a download anchor, and revokes the URL", () => {

--- a/src/utils/transcript-utils.test.ts
+++ b/src/utils/transcript-utils.test.ts
@@ -81,3 +81,44 @@ describe("getTranscriptFilename", () => {
     expect(name).toBe("davai-transcript-2026-06-23-unknown-llm.txt");
   });
 });
+
+import { copyTextToClipboard, downloadTextFile } from "./transcript-utils";
+
+describe("downloadTextFile", () => {
+  it("creates an object URL, clicks a download anchor, and revokes the URL", () => {
+    const createObjectURL = jest.fn(() => "blob:url");
+    const revokeObjectURL = jest.fn();
+    (global.URL as any).createObjectURL = createObjectURL;
+    (global.URL as any).revokeObjectURL = revokeObjectURL;
+
+    let anchor: HTMLAnchorElement | undefined;
+    const realCreate = document.createElement.bind(document);
+    const createElementSpy = jest.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = realCreate(tag);
+      if (tag === "a") anchor = el as HTMLAnchorElement;
+      return el;
+    });
+    const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+
+    downloadTextFile("my-file.txt", "hello");
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(anchor?.download).toBe("my-file.txt");
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:url");
+
+    createElementSpy.mockRestore();
+    clickSpy.mockRestore();
+  });
+});
+
+describe("copyTextToClipboard", () => {
+  it("writes the text via the clipboard API", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    await copyTextToClipboard("hello clipboard");
+
+    expect(writeText).toHaveBeenCalledWith("hello clipboard");
+  });
+});

--- a/src/utils/transcript-utils.test.ts
+++ b/src/utils/transcript-utils.test.ts
@@ -66,6 +66,24 @@ describe("buildTranscriptCsv", () => {
     expect(out).toContain('"T","User","","has ""quote"", and comma"');
   });
 
+  it("neutralizes spreadsheet formula injection by prefixing dangerous fields with '", () => {
+    const { csv } = buildTranscriptCsv([
+      { speaker: "User", timestamp: "T1", id: "a", messageContent: { content: "=SUM(A1:A2)" }, plainTextContent: "=SUM(A1:A2)" },
+      { speaker: "DAVAI", timestamp: "T2", id: "b", messageContent: { content: "- bullet point" }, plainTextContent: "- bullet point" },
+      { speaker: "User", timestamp: "T3", id: "c", messageContent: { content: "@handle" }, plainTextContent: "@handle" },
+    ]);
+    expect(csv).toContain(`"T1","User","","'=SUM(A1:A2)"`);
+    expect(csv).toContain(`"T2","DAVAI","","'- bullet point"`);
+    expect(csv).toContain(`"T3","User","","'@handle"`);
+  });
+
+  it("does not prefix fields that start with a safe character", () => {
+    const { csv } = buildTranscriptCsv([
+      { speaker: "User", timestamp: "T", id: "d", messageContent: { content: "hello = world" }, plainTextContent: "hello = world" },
+    ]);
+    expect(csv).toContain('"T","User","","hello = world"');
+  });
+
   it("returns no images when the transcript has none", () => {
     const { images } = buildTranscriptCsv(messages);
     expect(images).toHaveLength(0);

--- a/src/utils/transcript-utils.test.ts
+++ b/src/utils/transcript-utils.test.ts
@@ -1,0 +1,83 @@
+import { ChatMessage } from "../types";
+import { formatTranscriptForCapture, getLlmLabel, getTranscriptFilename } from "./transcript-utils";
+
+const messages: ChatMessage[] = [
+  {
+    speaker: "User",
+    timestamp: "T1",
+    id: "1",
+    messageContent: { content: "**bold** question" },
+    plainTextContent: "bold question",
+  },
+  {
+    speaker: "DAVAI",
+    timestamp: "T2",
+    id: "2",
+    messageContent: { content: "the _answer_" },
+    plainTextContent: "the answer",
+  },
+  {
+    speaker: "Debug Log",
+    timestamp: "T3",
+    id: "3",
+    messageContent: { description: "tool call", content: "{\"a\":1}" },
+    plainTextContent: "",
+  },
+];
+
+describe("formatTranscriptForCapture", () => {
+  const text = formatTranscriptForCapture(messages, {
+    capturedAt: "CAPTURE_TIME",
+    llmLabel: "Anthropic: claude-haiku-4-5",
+  });
+
+  it("includes a header with capture time and LLM label", () => {
+    expect(text).toContain("DAVAI Chat Transcript");
+    expect(text).toContain("Captured: CAPTURE_TIME");
+    expect(text).toContain("LLM: Anthropic: claude-haiku-4-5");
+  });
+
+  it("renders normal messages as speaker + timestamp + stripped text", () => {
+    expect(text).toContain("User (T1):\nbold question");
+    expect(text).toContain("DAVAI (T2):\nthe answer");
+    expect(text).not.toContain("**bold**");
+  });
+
+  it("includes debug-log entries with description and raw content", () => {
+    expect(text).toContain("Debug Log (T3):\ntool call\n{\"a\":1}");
+  });
+});
+
+describe("getLlmLabel", () => {
+  it("formats provider and id", () => {
+    expect(getLlmLabel("{\"id\":\"claude-haiku-4-5\",\"provider\":\"Anthropic\"}"))
+      .toBe("Anthropic: claude-haiku-4-5");
+  });
+
+  it("falls back to Unknown LLM for bad JSON", () => {
+    expect(getLlmLabel("not json")).toBe("Unknown LLM");
+  });
+});
+
+describe("getTranscriptFilename", () => {
+  it("builds a dated, LLM-named filename", () => {
+    const name = getTranscriptFilename(
+      "{\"id\":\"claude-haiku-4-5\",\"provider\":\"Anthropic\"}",
+      new Date(2026, 5, 23)
+    );
+    expect(name).toBe("davai-transcript-2026-06-23-claude-haiku-4-5.txt");
+  });
+
+  it("sanitizes unsafe characters in the id", () => {
+    const name = getTranscriptFilename(
+      "{\"id\":\"gpt-4o/mini\",\"provider\":\"OpenAI\"}",
+      new Date(2026, 0, 5)
+    );
+    expect(name).toBe("davai-transcript-2026-01-05-gpt-4o-mini.txt");
+  });
+
+  it("falls back to unknown-llm for unparseable llmId", () => {
+    const name = getTranscriptFilename("not json", new Date(2026, 5, 23));
+    expect(name).toBe("davai-transcript-2026-06-23-unknown-llm.txt");
+  });
+});

--- a/src/utils/transcript-utils.test.ts
+++ b/src/utils/transcript-utils.test.ts
@@ -1,5 +1,5 @@
 import { ChatMessage } from "../types";
-import { copyTextToClipboard, downloadTextFile, formatTranscriptForCapture, getLlmLabel, getTranscriptFilename } from "./transcript-utils";
+import { copyTextToClipboard, downloadTextFile, formatTranscriptForCapture, getTranscriptFilename } from "./transcript-utils";
 
 const messages: ChatMessage[] = [
   {
@@ -26,36 +26,34 @@ const messages: ChatMessage[] = [
 ];
 
 describe("formatTranscriptForCapture", () => {
-  const text = formatTranscriptForCapture(messages, {
-    capturedAt: "CAPTURE_TIME",
-    llmLabel: "Anthropic: claude-haiku-4-5",
+  const csv = formatTranscriptForCapture(messages);
+  const lines = csv.replace(/\r\n$/, "").split("\r\n");
+
+  it("starts with a CSV header row", () => {
+    expect(lines[0]).toBe('"timestamp","speaker","debug event","message"');
   });
 
-  it("includes a header with capture time and LLM label", () => {
-    expect(text).toContain("DAVAI Chat Transcript");
-    expect(text).toContain("Captured: CAPTURE_TIME");
-    expect(text).toContain("LLM: Anthropic: claude-haiku-4-5");
+  it("renders normal messages with a blank debug event and markdown-stripped text", () => {
+    expect(lines[1]).toBe('"T1","User","","bold question"');
+    expect(lines[2]).toBe('"T2","DAVAI","","the answer"');
+    expect(csv).not.toContain("**bold**");
   });
 
-  it("renders normal messages as speaker + timestamp + stripped text", () => {
-    expect(text).toContain("User (T1):\nbold question");
-    expect(text).toContain("DAVAI (T2):\nthe answer");
-    expect(text).not.toContain("**bold**");
+  it("renders debug-log entries with the description in debug event and raw content in message", () => {
+    expect(lines[3]).toBe('"T3","Debug Log","tool call","{""a"":1}"');
   });
 
-  it("includes debug-log entries with description and raw content", () => {
-    expect(text).toContain("Debug Log (T3):\ntool call\n{\"a\":1}");
-  });
-});
-
-describe("getLlmLabel", () => {
-  it("formats provider and id", () => {
-    expect(getLlmLabel("{\"id\":\"claude-haiku-4-5\",\"provider\":\"Anthropic\"}"))
-      .toBe("Anthropic: claude-haiku-4-5");
-  });
-
-  it("falls back to Unknown LLM for bad JSON", () => {
-    expect(getLlmLabel("not json")).toBe("Unknown LLM");
+  it("quotes every field and escapes embedded quotes and commas", () => {
+    const out = formatTranscriptForCapture([
+      {
+        speaker: "User",
+        timestamp: "T",
+        id: "x",
+        messageContent: { content: 'has "quote", and comma' },
+        plainTextContent: 'has "quote", and comma',
+      },
+    ]);
+    expect(out).toContain('"T","User","","has ""quote"", and comma"');
   });
 });
 
@@ -65,7 +63,7 @@ describe("getTranscriptFilename", () => {
       "{\"id\":\"claude-haiku-4-5\",\"provider\":\"Anthropic\"}",
       new Date(2026, 5, 23)
     );
-    expect(name).toBe("davai-transcript-2026-06-23-claude-haiku-4-5.txt");
+    expect(name).toBe("davai-transcript-2026-06-23-claude-haiku-4-5.csv");
   });
 
   it("sanitizes unsafe characters in the id", () => {
@@ -73,12 +71,12 @@ describe("getTranscriptFilename", () => {
       "{\"id\":\"gpt-4o/mini\",\"provider\":\"OpenAI\"}",
       new Date(2026, 0, 5)
     );
-    expect(name).toBe("davai-transcript-2026-01-05-gpt-4o-mini.txt");
+    expect(name).toBe("davai-transcript-2026-01-05-gpt-4o-mini.csv");
   });
 
   it("falls back to unknown-llm for unparseable llmId", () => {
     const name = getTranscriptFilename("not json", new Date(2026, 5, 23));
-    expect(name).toBe("davai-transcript-2026-06-23-unknown-llm.txt");
+    expect(name).toBe("davai-transcript-2026-06-23-unknown-llm.csv");
   });
 });
 

--- a/src/utils/transcript-utils.test.ts
+++ b/src/utils/transcript-utils.test.ts
@@ -1,5 +1,15 @@
+import { strFromU8, unzipSync } from "fflate";
 import { ChatMessage } from "../types";
-import { copyTextToClipboard, downloadTextFile, formatTranscriptForCapture, getTranscriptFilename } from "./transcript-utils";
+import { buildTranscriptCsv, buildTranscriptZip, copyTextToClipboard, downloadTextFile, getTranscriptFilename } from "./transcript-utils";
+
+const imageDataUri = "data:image/png;base64,aGVsbG8=";
+const debugWithImage: ChatMessage = {
+  speaker: "Debug Log",
+  timestamp: "T4",
+  id: "4",
+  messageContent: { description: "Response from CODAP", content: `{"exportDataUri":"${imageDataUri}"}` },
+  plainTextContent: "",
+};
 
 const messages: ChatMessage[] = [
   {
@@ -25,8 +35,8 @@ const messages: ChatMessage[] = [
   },
 ];
 
-describe("formatTranscriptForCapture", () => {
-  const csv = formatTranscriptForCapture(messages);
+describe("buildTranscriptCsv", () => {
+  const { csv } = buildTranscriptCsv(messages);
   const lines = csv.replace(/\r\n$/, "").split("\r\n");
 
   it("starts with a CSV header row", () => {
@@ -44,7 +54,7 @@ describe("formatTranscriptForCapture", () => {
   });
 
   it("quotes every field and escapes embedded quotes and commas", () => {
-    const out = formatTranscriptForCapture([
+    const { csv: out } = buildTranscriptCsv([
       {
         speaker: "User",
         timestamp: "T",
@@ -54,6 +64,55 @@ describe("formatTranscriptForCapture", () => {
       },
     ]);
     expect(out).toContain('"T","User","","has ""quote"", and comma"');
+  });
+
+  it("returns no images when the transcript has none", () => {
+    const { images } = buildTranscriptCsv(messages);
+    expect(images).toHaveLength(0);
+  });
+});
+
+describe("buildTranscriptCsv image extraction", () => {
+  it("replaces a base64 image with an images/ reference and returns its bytes", () => {
+    const { csv, images } = buildTranscriptCsv([debugWithImage]);
+    expect(csv).toContain("images/image-001.png");
+    expect(csv).not.toContain("aGVsbG8=");
+    expect(images).toHaveLength(1);
+    expect(images[0].filename).toBe("image-001.png");
+    expect(images[0].bytes.length).toBeGreaterThan(0);
+  });
+
+  it("de-duplicates an identical image into one file referenced from both rows", () => {
+    const second: ChatMessage = {
+      ...debugWithImage,
+      id: "5",
+      timestamp: "T5",
+      messageContent: { description: "Tool output generated", content: `{"url":"${imageDataUri}"}` },
+    };
+    const { csv, images } = buildTranscriptCsv([debugWithImage, second]);
+    expect(images).toHaveLength(1);
+    expect((csv.match(/images\/image-001\.png/g) || []).length).toBe(2);
+  });
+
+  it("numbers distinct images sequentially with an extension from the mime type", () => {
+    const jpeg: ChatMessage = {
+      ...debugWithImage,
+      id: "6",
+      timestamp: "T6",
+      messageContent: { description: "img", content: "data:image/jpeg;base64,d29ybGQ=" },
+    };
+    const { images } = buildTranscriptCsv([debugWithImage, jpeg]);
+    expect(images.map((i) => i.filename)).toEqual(["image-001.png", "image-002.jpg"]);
+  });
+});
+
+describe("buildTranscriptZip", () => {
+  it("bundles the CSV and images and round-trips via unzip", () => {
+    const capture = buildTranscriptCsv([debugWithImage]);
+    const entries = unzipSync(buildTranscriptZip(capture));
+    expect(Object.keys(entries).sort()).toEqual(["images/image-001.png", "transcript.csv"]);
+    expect(strFromU8(entries["transcript.csv"])).toContain("images/image-001.png");
+    expect(strFromU8(entries["images/image-001.png"])).toBe("hello");
   });
 });
 
@@ -77,6 +136,15 @@ describe("getTranscriptFilename", () => {
   it("falls back to unknown-llm for unparseable llmId", () => {
     const name = getTranscriptFilename("not json", new Date(2026, 5, 23));
     expect(name).toBe("davai-transcript-2026-06-23-unknown-llm.csv");
+  });
+
+  it("uses the given extension", () => {
+    const name = getTranscriptFilename(
+      "{\"id\":\"mock\",\"provider\":\"Mock\"}",
+      new Date(2026, 5, 23),
+      "zip"
+    );
+    expect(name).toBe("davai-transcript-2026-06-23-mock.zip");
   });
 });
 

--- a/src/utils/transcript-utils.ts
+++ b/src/utils/transcript-utils.ts
@@ -1,3 +1,4 @@
+import { strToU8, zipSync } from "fflate";
 import { ChatMessage } from "../types";
 import { DEBUG_SPEAKER } from "../constants";
 
@@ -5,15 +6,74 @@ import { DEBUG_SPEAKER } from "../constants";
 // DAVAI/User rows leave it blank.
 const CSV_HEADER = ["timestamp", "speaker", "debug event", "message"];
 
-export function formatTranscriptForCapture(messages: ChatMessage[]): string {
+// Matches a base64 image data URI (e.g. CODAP's graph exportDataUri). The base64
+// run ends at the first non-base64 char (e.g. the closing quote in the debug JSON).
+const IMAGE_DATA_URI_RE = /data:image\/[A-Za-z0-9.+-]+;base64,[A-Za-z0-9+/=]+/g;
+
+export interface CapturedImage {
+  /** File name within the zip's images/ folder, e.g. "image-001.png". */
+  filename: string;
+  bytes: Uint8Array;
+}
+
+export interface TranscriptCapture {
+  /** CSV text, with image data URIs replaced by images/<filename> references. */
+  csv: string;
+  /** Decoded images referenced by the CSV, de-duplicated by content. */
+  images: CapturedImage[];
+}
+
+export function buildTranscriptCsv(messages: ChatMessage[]): TranscriptCapture {
+  const images: CapturedImage[] = [];
+  const refByDataUri = new Map<string, string>();
+
+  // Replace each base64 image with a stable images/<filename> reference, decoding
+  // the bytes once per unique image so identical images share a single file.
+  const replaceImages = (text: string): string =>
+    text.replace(IMAGE_DATA_URI_RE, (dataUri) => {
+      const existingRef = refByDataUri.get(dataUri);
+      if (existingRef) return existingRef;
+      const filename = `image-${String(images.length + 1).padStart(3, "0")}.${imageExtFromDataUri(dataUri)}`;
+      images.push({ filename, bytes: dataUriToBytes(dataUri) });
+      const ref = `images/${filename}`;
+      refByDataUri.set(dataUri, ref);
+      return ref;
+    });
+
   const rows = messages.map((message) => {
     const isDebug = message.speaker === DEBUG_SPEAKER;
     const debugEvent = isDebug ? message.messageContent.description ?? "" : "";
-    const body = isDebug ? message.messageContent.content : message.plainTextContent;
-    return [message.timestamp, message.speaker, debugEvent, body];
+    const rawBody = isDebug ? message.messageContent.content : message.plainTextContent;
+    return [message.timestamp, message.speaker, debugEvent, replaceImages(rawBody ?? "")];
   });
 
-  return [CSV_HEADER, ...rows].map(toCsvRow).join("\r\n") + "\r\n";
+  const csv = [CSV_HEADER, ...rows].map(toCsvRow).join("\r\n") + "\r\n";
+  return { csv, images };
+}
+
+/** Bundle the CSV (as transcript.csv) and its images (under images/) into a zip. */
+export function buildTranscriptZip(capture: TranscriptCapture): Uint8Array {
+  const files: Record<string, Uint8Array> = { "transcript.csv": strToU8(capture.csv) };
+  for (const image of capture.images) {
+    files[`images/${image.filename}`] = image.bytes;
+  }
+  return zipSync(files);
+}
+
+function imageExtFromDataUri(dataUri: string): string {
+  const mime = dataUri.match(/^data:image\/([A-Za-z0-9.+-]+);base64,/)?.[1]?.toLowerCase();
+  if (mime === "jpeg" || mime === "jpg") return "jpg";
+  if (mime === "svg+xml") return "svg";
+  return mime || "png";
+}
+
+function dataUriToBytes(dataUri: string): Uint8Array {
+  const binary = atob(dataUri.split(",")[1] ?? "");
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
 }
 
 function toCsvRow(fields: string[]): string {
@@ -26,10 +86,10 @@ function escapeCsvField(value: string): string {
   return `"${(value ?? "").replace(/"/g, '""')}"`;
 }
 
-export function getTranscriptFilename(llmId: string, now: Date): string {
+export function getTranscriptFilename(llmId: string, now: Date, ext = "csv"): string {
   const datePart = formatDateForFilename(now);
   const idPart = sanitizeForFilename(parseLlmIdForFilename(llmId));
-  return `davai-transcript-${datePart}-${idPart}.csv`;
+  return `davai-transcript-${datePart}-${idPart}.${ext}`;
 }
 
 function formatDateForFilename(now: Date): string {
@@ -55,8 +115,7 @@ function sanitizeForFilename(value: string): string {
   return value.replace(/[^a-zA-Z0-9.-]/g, "-");
 }
 
-export function downloadTextFile(filename: string, text: string): void {
-  const blob = new Blob([text], { type: "text/plain" });
+export function downloadBlob(filename: string, blob: Blob): void {
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
   anchor.href = url;
@@ -65,6 +124,10 @@ export function downloadTextFile(filename: string, text: string): void {
   anchor.click();
   document.body.removeChild(anchor);
   URL.revokeObjectURL(url);
+}
+
+export function downloadTextFile(filename: string, text: string): void {
+  downloadBlob(filename, new Blob([text], { type: "text/plain" }));
 }
 
 export async function copyTextToClipboard(text: string): Promise<void> {

--- a/src/utils/transcript-utils.ts
+++ b/src/utils/transcript-utils.ts
@@ -82,8 +82,15 @@ function toCsvRow(fields: string[]): string {
 
 // RFC 4180: wrap every field in double quotes and double any internal quotes,
 // so commas, quotes, and newlines in messages or debug JSON don't break columns.
+// Also guard against CSV injection: spreadsheet apps evaluate a cell whose first
+// character is = + - @ (or a leading tab/CR) as a formula, and quoting alone does
+// not prevent that. Prefix such fields with ' to force literal text. (Side effect:
+// markdown bullets like "- x" also get the ' — invisible in spreadsheets, literal
+// only on programmatic re-parse.)
 function escapeCsvField(value: string): string {
-  return `"${(value ?? "").replace(/"/g, '""')}"`;
+  const normalized = value ?? "";
+  const safe = /^[=+\-@\t\r]/.test(normalized) ? `'${normalized}` : normalized;
+  return `"${safe.replace(/"/g, '""')}"`;
 }
 
 export function getTranscriptFilename(llmId: string, now: Date, ext = "csv"): string {

--- a/src/utils/transcript-utils.ts
+++ b/src/utils/transcript-utils.ts
@@ -65,3 +65,19 @@ function parseLlmIdForFilename(llmId: string): string {
 function sanitizeForFilename(value: string): string {
   return value.replace(/[^a-zA-Z0-9.-]/g, "-");
 }
+
+export function downloadTextFile(filename: string, text: string): void {
+  const blob = new Blob([text], { type: "text/plain" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+export async function copyTextToClipboard(text: string): Promise<void> {
+  await navigator.clipboard.writeText(text);
+}

--- a/src/utils/transcript-utils.ts
+++ b/src/utils/transcript-utils.ts
@@ -126,10 +126,6 @@ export function downloadBlob(filename: string, blob: Blob): void {
   URL.revokeObjectURL(url);
 }
 
-export function downloadTextFile(filename: string, text: string): void {
-  downloadBlob(filename, new Blob([text], { type: "text/plain" }));
-}
-
 export async function copyTextToClipboard(text: string): Promise<void> {
   await navigator.clipboard.writeText(text);
 }

--- a/src/utils/transcript-utils.ts
+++ b/src/utils/transcript-utils.ts
@@ -1,46 +1,35 @@
 import { ChatMessage } from "../types";
 import { DEBUG_SPEAKER } from "../constants";
 
-interface CaptureMeta {
-  capturedAt: string;
-  llmLabel: string;
-}
+// CSV columns. Debug-log rows put their event description in "debug event";
+// DAVAI/User rows leave it blank.
+const CSV_HEADER = ["timestamp", "speaker", "debug event", "message"];
 
-export function formatTranscriptForCapture(messages: ChatMessage[], meta: CaptureMeta): string {
-  const header = [
-    "DAVAI Chat Transcript",
-    `Captured: ${meta.capturedAt}`,
-    `LLM: ${meta.llmLabel}`,
-  ].join("\n");
-
-  const blocks = messages.map((message) => {
-    const heading = `${message.speaker} (${message.timestamp}):`;
-    if (message.speaker === DEBUG_SPEAKER) {
-      const { description, content } = message.messageContent;
-      return [heading, description, content].filter(Boolean).join("\n");
-    }
-    return `${heading}\n${message.plainTextContent}`;
+export function formatTranscriptForCapture(messages: ChatMessage[]): string {
+  const rows = messages.map((message) => {
+    const isDebug = message.speaker === DEBUG_SPEAKER;
+    const debugEvent = isDebug ? message.messageContent.description ?? "" : "";
+    const body = isDebug ? message.messageContent.content : message.plainTextContent;
+    return [message.timestamp, message.speaker, debugEvent, body];
   });
 
-  return [header, ...blocks].join("\n\n") + "\n";
+  return [CSV_HEADER, ...rows].map(toCsvRow).join("\r\n") + "\r\n";
 }
 
-export function getLlmLabel(llmId: string): string {
-  try {
-    const parsed = JSON.parse(llmId);
-    if (parsed && typeof parsed.id === "string") {
-      return parsed.provider ? `${parsed.provider}: ${parsed.id}` : parsed.id;
-    }
-  } catch {
-    // fall through to default
-  }
-  return "Unknown LLM";
+function toCsvRow(fields: string[]): string {
+  return fields.map(escapeCsvField).join(",");
+}
+
+// RFC 4180: wrap every field in double quotes and double any internal quotes,
+// so commas, quotes, and newlines in messages or debug JSON don't break columns.
+function escapeCsvField(value: string): string {
+  return `"${(value ?? "").replace(/"/g, '""')}"`;
 }
 
 export function getTranscriptFilename(llmId: string, now: Date): string {
   const datePart = formatDateForFilename(now);
   const idPart = sanitizeForFilename(parseLlmIdForFilename(llmId));
-  return `davai-transcript-${datePart}-${idPart}.txt`;
+  return `davai-transcript-${datePart}-${idPart}.csv`;
 }
 
 function formatDateForFilename(now: Date): string {

--- a/src/utils/transcript-utils.ts
+++ b/src/utils/transcript-utils.ts
@@ -1,0 +1,67 @@
+import { ChatMessage } from "../types";
+import { DEBUG_SPEAKER } from "../constants";
+
+interface CaptureMeta {
+  capturedAt: string;
+  llmLabel: string;
+}
+
+export function formatTranscriptForCapture(messages: ChatMessage[], meta: CaptureMeta): string {
+  const header = [
+    "DAVAI Chat Transcript",
+    `Captured: ${meta.capturedAt}`,
+    `LLM: ${meta.llmLabel}`,
+  ].join("\n");
+
+  const blocks = messages.map((message) => {
+    const heading = `${message.speaker} (${message.timestamp}):`;
+    if (message.speaker === DEBUG_SPEAKER) {
+      const { description, content } = message.messageContent;
+      return [heading, description, content].filter(Boolean).join("\n");
+    }
+    return `${heading}\n${message.plainTextContent}`;
+  });
+
+  return [header, ...blocks].join("\n\n") + "\n";
+}
+
+export function getLlmLabel(llmId: string): string {
+  try {
+    const parsed = JSON.parse(llmId);
+    if (parsed && typeof parsed.id === "string") {
+      return parsed.provider ? `${parsed.provider}: ${parsed.id}` : parsed.id;
+    }
+  } catch {
+    // fall through to default
+  }
+  return "Unknown LLM";
+}
+
+export function getTranscriptFilename(llmId: string, now: Date): string {
+  const datePart = formatDateForFilename(now);
+  const idPart = sanitizeForFilename(parseLlmIdForFilename(llmId));
+  return `davai-transcript-${datePart}-${idPart}.txt`;
+}
+
+function formatDateForFilename(now: Date): string {
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function parseLlmIdForFilename(llmId: string): string {
+  try {
+    const parsed = JSON.parse(llmId);
+    if (parsed && typeof parsed.id === "string" && parsed.id.trim()) {
+      return parsed.id;
+    }
+  } catch {
+    // fall through to default
+  }
+  return "unknown-llm";
+}
+
+function sanitizeForFilename(value: string): string {
+  return value.replace(/[^a-zA-Z0-9.-]/g, "-");
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,13 +64,13 @@ module.exports = (env, argv) => {
         cert: path.resolve(os.homedir(), '.localhost-ssl/localhost.pem'),
       },
       proxy: [
-        // Proxy anything not available locally to codap3.concord.org
-        // This makes it possible to load CODAP at https://localhost:8080/branch/main
-        // and the plugin at https://localhost:8080/ this way the plugin can be
-        // embedded in CODAP during development.
+        // Proxy anything not available locally to codap.concord.org (production CODAP,
+        // served at /app/). This makes it possible to load CODAP at
+        // https://localhost:8080/app/ and the plugin at https://localhost:8080/ so the
+        // plugin can be embedded in CODAP same-origin during development.
         {
           context: ['/'],
-          target: 'https://codap3.concord.org',
+          target: 'https://codap.concord.org',
           secure: true,
           changeOrigin: true,
         }


### PR DESCRIPTION
## Summary

Adds a way to capture the chat transcript (DAVAI-104), plus a small accessibility improvement to the Keyboard Shortcuts options.

- **Capture button + `Control+Shift+;` shortcut** in the chat-transcript header. Triggering it copies the transcript to the clipboard **and** downloads it.
- **Output is CSV** with columns `timestamp, speaker, debug event, message` (RFC-4180 quoted so commas/quotes/newlines in messages or debug JSON stay intact). `debug event` holds the debug entry's description and is blank for DAVAI/User rows.
- **Large base64 images** (CODAP graph `exportDataUri` in debug rows) are extracted out of the CSV: each `data:image/…;base64,…` becomes an `images/image-NNN.<ext>` reference, de-duplicated by content. When images are present the download is a **`.zip`** (`transcript.csv` + `images/`, via `fflate`); otherwise a plain `.csv`. The clipboard always gets the readable reference-substituted CSV.
- **Filename** includes the date and selected LLM: `davai-transcript-<YYYY-MM-DD>-<llm-id>.csv` (or `.zip`).
- **Keyboard Shortcuts options** now list *every* shortcut, each with a description and its own customize field (previously only `focusChatInput` was editable).
- Drive-by: corrected the stale dev-server docs (port **8080** + CODAP proxy, not 8081) in `CLAUDE.md` and `README.md`.

## Implementation notes

- New `src/utils/transcript-utils.ts`: `buildTranscriptCsv` (CSV + extracted images), `buildTranscriptZip`, CSV escaping, filename, and clipboard/download helpers — pure logic separated from DOM side effects.
- New `captureTranscript` keyboard-shortcut config key (default `Control+Shift+Semicolon`).
- Added `fflate` (tiny, zero-dep) for zipping.

## Testing

- `npm test` — 231/231 passing (unit tests for CSV formatting/escaping, image extraction + de-dup, mime→extension, zip round-trip; component tests for button click, the `application/zip` download path, and that base64 never reaches the clipboard).
- `npm run lint:build` — clean.
- Manually verified in CODAP via the local dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)