### PR TITLE
Fix flaky standalone Cypress test (no-CODAP timeout errors)

### DIFF
--- a/cypress/e2e/workspace.test.ts
+++ b/cypress/e2e/workspace.test.ts
@@ -4,5 +4,11 @@ context("Test the overall app", () => {
     cy.get("body").should("contain", "DAVAI");
     cy.get("[data-testid=chat-transcript]").should("exist");
     cy.get("[data-testid=chat-input]").should("exist");
+    // With no CODAP host, the plugin's CODAP API requests (fired on mount) time out after
+    // iframe-phone's hard-coded 2s and throw. That throw is ignored by the
+    // uncaught:exception handler in support/e2e.js, but only when it fires during the test;
+    // if it lands in an after-all hook (which happens on slower builds) Cypress fails the
+    // spec regardless. Wait past the 2s timeout so the throw is absorbed here, in the test.
+    cy.wait(3000);
   });
 });

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -30,15 +30,18 @@ import "@cypress/code-coverage/support";
 //   2. a TypeError "Cannot read properties of undefined (reading 'success')" thrown when
 //      selectSelf's callback receives the undefined timeout result.
 // For (1) the rejection reason is a string, so err.stack is Cypress's runner stack, not
-// codap-plugin-api — match on the message as well as the stack. Errors from our own code
-// still fail the test.
+// codap-plugin-api, and a non-Error reason has no .message — so search String(err) too.
+// Only these two no-host cases are ignored (the TypeError must come from the CODAP comms
+// layer); real bugs in our code, or elsewhere in those libraries, still fail the test.
 Cypress.on("uncaught:exception", (err) => {
-  const text = `${err?.message || ""}\n${err?.stack || ""}`;
-  const fromCodapNoHost =
+  const text = `${err?.message || ""}\n${err?.stack || ""}\n${String(err)}`;
+  const fromCodapComms = text.includes("codap-plugin-api") || text.includes("iframe-phone");
+  const isNoHostTimeout =
+    // (1) the rejected promise whose reason is the timeout string
     text.includes("CODAP request timed out") ||
-    text.includes("Cannot read properties of undefined (reading 'success')") ||
-    text.includes("codap-plugin-api") ||
-    text.includes("iframe-phone");
+    // (2) selectSelf reading `success` off the undefined timeout result — only when the
+    //     throw actually originates in the CODAP comms layer
+    (fromCodapComms && /reading '?success'?/.test(text));
   // Returning false tells Cypress to ignore the error; anything else lets it fail.
-  return !fromCodapNoHost;
+  return !isNoHostTimeout;
 });

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -24,12 +24,21 @@ import "@cypress/code-coverage/support";
 
 // The plugin talks to CODAP through the CODAP plugin API (iframe-phone). These specs
 // load the plugin standalone, with no CODAP host, so codap-plugin-api requests time
-// out and call back with `undefined` — and the library then throws asynchronously
-// (e.g. selectSelf reading `result.success`). Those library-level errors are expected
-// here and unrelated to whether the app renders, so don't let them fail the spec.
-// Errors originating in our own code still fail the test.
+// out after iframe-phone's 2s limit. That surfaces two expected, app-level errors that
+// are unrelated to whether the app renders:
+//   1. a rejected promise whose reason is the string "...CODAP request timed out...",
+//   2. a TypeError "Cannot read properties of undefined (reading 'success')" thrown when
+//      selectSelf's callback receives the undefined timeout result.
+// For (1) the rejection reason is a string, so err.stack is Cypress's runner stack, not
+// codap-plugin-api — match on the message as well as the stack. Errors from our own code
+// still fail the test.
 Cypress.on("uncaught:exception", (err) => {
-  const fromCodapComms = err.stack?.includes("codap-plugin-api") || err.stack?.includes("iframe-phone");
+  const text = `${err?.message || ""}\n${err?.stack || ""}`;
+  const fromCodapNoHost =
+    text.includes("CODAP request timed out") ||
+    text.includes("Cannot read properties of undefined (reading 'success')") ||
+    text.includes("codap-plugin-api") ||
+    text.includes("iframe-phone");
   // Returning false tells Cypress to ignore the error; anything else lets it fail.
-  return !fromCodapComms;
+  return !fromCodapNoHost;
 });


### PR DESCRIPTION
## Problem

`cypress/e2e/workspace.test.ts` loads the plugin with **no CODAP host**, so its CODAP-API requests time out after iframe-phone's hard-coded 2s and surface two **expected** app-level errors (unrelated to whether the app renders):

1. a rejected promise whose reason is the string `"...CODAP request timed out..."`, and
2. a `TypeError: Cannot read properties of undefined (reading 'success')` thrown when `selectSelf`'s callback gets the undefined timeout result.

The existing `uncaught:exception` handler only matched `err.stack`, which **misses (1)** — its rejection reason is a string, so the stack is Cypress's runner, not `codap-plugin-api`. As a result the spec only passed when the 2s errors happened to fire in a harmless window; on slower builds (notably the production-secrets **tag build**) they landed in an `after all` hook and failed the spec deterministically. This blocked tagged releases.

## Fix

- Match the expected no-CODAP errors by **message and stack** (covers the string-rejection case).
- `cy.wait(3000)` after the assertions so the 2s timeout errors fire **during the test** (where the handler applies) rather than in an after-all hook (which Cypress fails regardless of the handler).

Errors originating in our own code still fail the test.

## Verification

Ran `npx cypress run` 4× locally — **4/4 pass** (previously failed deterministically once the error was forced into the test window). `npm run lint:build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)