### PR TITLE
DAVAI-56: recover from failed tool calls instead of breaking the thread

### DIFF
--- a/sam-server/src/handlers/job-processor.ts
+++ b/sam-server/src/handlers/job-processor.ts
@@ -2,7 +2,7 @@ import { SQSEvent } from "aws-lambda";
 import { Pool } from "pg";
 import { HumanMessage, ToolMessage } from "@langchain/core/messages";
 import { getLangApp } from "../utils/llm-utils";
-import { extractToolCalls, toolCallResponse } from "../utils/tool-utils";
+import { buildToolRepairMessages, extractToolCalls, toolCallResponse } from "../utils/tool-utils";
 import { Job, ToolJob, MessageJob } from "../types";
 import { getLangSmithKey } from "../utils/env-utils";
 
@@ -88,14 +88,33 @@ export const handler = async (event: SQSEvent): Promise<void> => {
         configurable: { llmId: job.input.llmId, thread_id: job.input.threadId },
         signal: controller.signal
       };
-      const messages: any[] = [];
+
+      const app = await getLangApp();
+
+      // Self-heal: if the thread already holds a tool_use that never received a
+      // tool_result (e.g. a prior tool call threw before its result was submitted),
+      // inject synthetic error tool_results FIRST so this call doesn't 400 on the
+      // dangling tool_use. The reducer concatenates [prior..., these, new...], so
+      // they land immediately after the orphaned AIMessage(tool_use) at the tail.
+      // https://docs.langchain.com/oss/javascript/langchain/errors/INVALID_TOOL_RESULTS/
+      let priorMessages: any[] = [];
+      try {
+        const priorState = await app.getState(config);
+        priorMessages = priorState?.values?.messages ?? [];
+      } catch (stateError) {
+        console.warn(`Could not load thread state for ${messageId}; skipping tool-call repair:`, stateError);
+      }
+
+      const answeringToolCallId =
+        job.kind === "tool" ? (job as ToolJob).input.message.tool_call_id : undefined;
+      const messages: any[] = [...buildToolRepairMessages(priorMessages, answeringToolCallId)];
       let dataContexts: any = {};
       let graphs: any = [];
 
       if (job.kind === "tool") {
 
         const toolJob = job as ToolJob;
-        
+
         let toolMessageContent: string;
         let humanMessage;
 
@@ -121,7 +140,7 @@ export const handler = async (event: SQSEvent): Promise<void> => {
       }
 
       // Process with LangGraph
-      const result = await (await getLangApp()).invoke(
+      const result = await app.invoke(
         { messages, dataContexts, graphs },
         config
       );

--- a/sam-server/src/utils/tool-utils.test.ts
+++ b/sam-server/src/utils/tool-utils.test.ts
@@ -1,9 +1,10 @@
-import { BaseMessage } from "@langchain/core/messages";
+import { AIMessage, BaseMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
 import { createRequestTool,
          sonifyGraphTool,
          tools,
          toolCallResponse,
-         extractToolCalls
+         extractToolCalls,
+         getUnansweredToolCallIds
        } from "./tool-utils";
 
 describe("createRequestTool", () => {
@@ -75,5 +76,38 @@ describe("extractToolCalls", () => {
   it("should return empty array if tool_calls is not an array", () => {
     const msg = { tool_calls: "not-an-array" } as unknown as BaseMessage;
     expect(extractToolCalls(msg)).toEqual([]);
+  });
+});
+
+describe("getUnansweredToolCallIds", () => {
+  it("returns a tool_call id that has no following ToolMessage", () => {
+    const messages = [
+      new HumanMessage({ content: "hi" }),
+      new AIMessage({ content: "", tool_calls: [{ name: "create_request", args: {}, id: "call-1" }] }),
+    ];
+    expect(getUnansweredToolCallIds(messages)).toEqual(["call-1"]);
+  });
+
+  it("excludes tool calls that already have a matching ToolMessage", () => {
+    const messages = [
+      new AIMessage({ content: "", tool_calls: [{ name: "create_request", args: {}, id: "call-1" }] }),
+      new ToolMessage({ content: "ok", tool_call_id: "call-1" }),
+    ];
+    expect(getUnansweredToolCallIds(messages)).toEqual([]);
+  });
+
+  it("returns only the still-unanswered ids from a multi-tool-call message, in order", () => {
+    const messages = [
+      new AIMessage({ content: "", tool_calls: [
+        { name: "create_request", args: {}, id: "call-1" },
+        { name: "sonify_graph", args: {}, id: "call-2" },
+      ]}),
+      new ToolMessage({ content: "ok", tool_call_id: "call-2" }),
+    ];
+    expect(getUnansweredToolCallIds(messages)).toEqual(["call-1"]);
+  });
+
+  it("returns [] for an empty history", () => {
+    expect(getUnansweredToolCallIds([])).toEqual([]);
   });
 });

--- a/sam-server/src/utils/tool-utils.test.ts
+++ b/sam-server/src/utils/tool-utils.test.ts
@@ -70,6 +70,7 @@ describe("toolCallResponse", () => {
     const response = await toolCallResponse(toolCall);
     expect(response.status).toBe("requires_action");
     expect(response.tool_call_id).toBe("bad-1");
+    expect(response.request).toMatchObject({ status: "error" });
   });
 });
 

--- a/sam-server/src/utils/tool-utils.test.ts
+++ b/sam-server/src/utils/tool-utils.test.ts
@@ -4,7 +4,9 @@ import { createRequestTool,
          tools,
          toolCallResponse,
          extractToolCalls,
-         getUnansweredToolCallIds
+         getUnansweredToolCallIds,
+         buildToolRepairMessages,
+         TOOL_NOT_COMPLETED_ERROR
        } from "./tool-utils";
 
 describe("createRequestTool", () => {
@@ -109,5 +111,39 @@ describe("getUnansweredToolCallIds", () => {
 
   it("returns [] for an empty history", () => {
     expect(getUnansweredToolCallIds([])).toEqual([]);
+  });
+});
+
+describe("buildToolRepairMessages", () => {
+  it("creates one error ToolMessage per unanswered tool call", () => {
+    const messages = [
+      new AIMessage({ content: "", tool_calls: [{ name: "create_request", args: {}, id: "call-1" }] }),
+    ];
+    const repairs = buildToolRepairMessages(messages);
+    expect(repairs).toHaveLength(1);
+    expect(repairs[0].tool_call_id).toBe("call-1");
+    expect(JSON.parse(repairs[0].content as string)).toEqual({
+      status: "error",
+      error: TOOL_NOT_COMPLETED_ERROR,
+    });
+  });
+
+  it("excludes the tool call the current job is answering", () => {
+    const messages = [
+      new AIMessage({ content: "", tool_calls: [
+        { name: "create_request", args: {}, id: "call-1" },
+        { name: "create_request", args: {}, id: "call-2" },
+      ]}),
+    ];
+    const repairs = buildToolRepairMessages(messages, "call-1");
+    expect(repairs.map((r) => r.tool_call_id)).toEqual(["call-2"]);
+  });
+
+  it("returns [] when every tool call is already answered", () => {
+    const messages = [
+      new AIMessage({ content: "", tool_calls: [{ name: "create_request", args: {}, id: "call-1" }] }),
+      new ToolMessage({ content: "ok", tool_call_id: "call-1" }),
+    ];
+    expect(buildToolRepairMessages(messages)).toEqual([]);
   });
 });

--- a/sam-server/src/utils/tool-utils.test.ts
+++ b/sam-server/src/utils/tool-utils.test.ts
@@ -54,9 +54,22 @@ describe("toolCallResponse", () => {
     });
   });
 
-  it("should throw error if tool not found", async () => {
+  it("returns an answerable error response if the tool is not found (does not throw)", async () => {
     const toolCall = { name: "unknown_tool", args: {}, id: "xyz" };
-    await expect(toolCallResponse(toolCall)).rejects.toThrow("Tool unknown_tool not found");
+    const response = await toolCallResponse(toolCall);
+    expect(response).toMatchObject({
+      request: { status: "error" },
+      status: "requires_action",
+      tool_call_id: "xyz",
+      type: "unknown_tool",
+    });
+  });
+
+  it("never throws on schema-violating args and still yields an answerable response", async () => {
+    const toolCall = { name: "create_request", args: { unexpected: true }, id: "bad-1" };
+    const response = await toolCallResponse(toolCall);
+    expect(response.status).toBe("requires_action");
+    expect(response.tool_call_id).toBe("bad-1");
   });
 });
 

--- a/sam-server/src/utils/tool-utils.ts
+++ b/sam-server/src/utils/tool-utils.ts
@@ -1,4 +1,4 @@
-import type { BaseMessage } from "@langchain/core/messages";
+import { ToolMessage, type BaseMessage } from "@langchain/core/messages";
 import { tool } from "@langchain/core/tools";
 
 type SimpleTool = {
@@ -158,4 +158,27 @@ export function getUnansweredToolCallIds(messages: BaseMessage[]): string[] {
     }
   }
   return unanswered;
+}
+
+export const TOOL_NOT_COMPLETED_ERROR =
+  "The previous tool call did not complete and produced no result.";
+
+/**
+ * Synthesize an error tool_result (ToolMessage) for every tool_use in the thread
+ * that was never answered, so the next model call satisfies Anthropic's
+ * "every tool_use needs a tool_result" rule. Pass the id the current tool-job is
+ * already answering as `answeringToolCallId` so it is not double-answered.
+ */
+export function buildToolRepairMessages(
+  priorMessages: BaseMessage[],
+  answeringToolCallId?: string
+): ToolMessage[] {
+  return getUnansweredToolCallIds(priorMessages)
+    .filter((id) => id !== answeringToolCallId)
+    .map((id) =>
+      new ToolMessage({
+        tool_call_id: id,
+        content: JSON.stringify({ status: "error", error: TOOL_NOT_COMPLETED_ERROR }),
+      })
+    );
 }

--- a/sam-server/src/utils/tool-utils.ts
+++ b/sam-server/src/utils/tool-utils.ts
@@ -130,3 +130,32 @@ export const extractToolCalls = (lastMessage: BaseMessage | undefined): any[] =>
   }
   return (lastMessage as any).tool_calls;
 };
+
+/**
+ * Find tool_call ids in the thread that were never answered by a ToolMessage.
+ * Anthropic rejects any thread where a tool_use lacks a following tool_result, so
+ * these are the ids the server must synthesize results for. Order = first
+ * appearance; duplicates removed. Pure: accepts plain message-shaped objects.
+ */
+export function getUnansweredToolCallIds(messages: BaseMessage[]): string[] {
+  const answered = new Set<string>();
+  for (const message of messages) {
+    const toolCallId = (message as any).tool_call_id;
+    if (typeof toolCallId === "string") answered.add(toolCallId);
+  }
+
+  const unanswered: string[] = [];
+  const seen = new Set<string>();
+  for (const message of messages) {
+    const toolCalls = (message as any).tool_calls;
+    if (!Array.isArray(toolCalls)) continue;
+    for (const toolCall of toolCalls) {
+      const id = toolCall?.id;
+      if (typeof id === "string" && !answered.has(id) && !seen.has(id)) {
+        seen.add(id);
+        unanswered.push(id);
+      }
+    }
+  }
+  return unanswered;
+}

--- a/sam-server/src/utils/tool-utils.ts
+++ b/sam-server/src/utils/tool-utils.ts
@@ -110,18 +110,32 @@ export const sonifyGraphTool = tool(
 export const tools: SimpleTool[] = [createRequestTool as any, sonifyGraphTool as any];
 
 export const toolCallResponse = async (toolCall: any) => {
-  const definedTool = tools.find((t) => t.name === toolCall.name);
-  if (!definedTool) throw new Error(`Tool ${toolCall.name} not found`);
+  try {
+    const definedTool = tools.find((t) => t.name === toolCall.name);
+    if (!definedTool) throw new Error(`Tool ${toolCall.name} not found`);
 
-  const toolResult = await (definedTool as any).invoke(toolCall.args);
-  const parsedResult = JSON.parse(toolResult);
+    const toolResult = await (definedTool as any).invoke(toolCall.args);
+    const parsedResult = JSON.parse(toolResult);
 
-  return {
-    request: parsedResult,
-    status: "requires_action",
-    tool_call_id: toolCall.id,
-    type: definedTool.name,
-  };
+    return {
+      request: parsedResult,
+      status: "requires_action",
+      tool_call_id: toolCall.id,
+      type: definedTool.name,
+    };
+  } catch (error) {
+    // A tool_use MUST be answered by a tool_result or the Anthropic thread is left
+    // permanently broken (INVALID_TOOL_RESULTS). Throwing here would skip the client's
+    // tool round-trip and orphan the tool_use. Instead return an answerable error
+    // response: the client forwards it back as the tool result and the model recovers.
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      request: { status: "error", error: message },
+      status: "requires_action",
+      tool_call_id: toolCall?.id,
+      type: toolCall?.name ?? "unknown",
+    };
+  }
 };
 
 export const extractToolCalls = (lastMessage: BaseMessage | undefined): any[] => {

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -6,8 +6,14 @@ import { formatJsonMessage, formatElapsedTime } from "../utils/utils";
 import { getDataContexts, getGraphAttrData, getGraphByID, getTrimmedGraphDetails } from "../utils/codap-api-utils";
 import { isGraphSonifiable } from "../utils/graph-sonification-utils";
 import { ChatTranscriptModel } from "./chat-transcript-model";
-import { IToolCallData, IMessageResponse, ToolOutput } from "../types";
+import { IToolCallData, IToolRequestError, IMessageResponse, ToolOutput } from "../types";
 import { postMessage } from "../utils/llm-utils";
+
+// A tool call the server could not prepare comes back as an error payload rather
+// than a normal CODAP request. This guard narrows the union so the normal path can
+// safely use action/resource/etc.
+const isToolRequestError = (request: IToolCallData["request"]): request is IToolRequestError =>
+  "status" in request && request.status === "error";
 
 /**
  * AssistantModel encapsulates the AI assistant and its interactions with the user.
@@ -121,7 +127,7 @@ export const AssistantModel = types
         // A tool call the server couldn't prepare comes back as an error payload.
         // Forward it straight back as the tool result (no CODAP round-trip) so the
         // tool_use is still answered and the model can recover in this same turn.
-        if (data.request?.status === "error") {
+        if (isToolRequestError(data.request)) {
           self.addDbgMsg("Tool call could not be prepared", formatJsonMessage(data.request));
           return JSON.stringify(data.request);
         }

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -118,6 +118,14 @@ export const AssistantModel = types
 
     const processToolCall = flow(function* (data: IToolCallData) {
       try {
+        // A tool call the server couldn't prepare comes back as an error payload.
+        // Forward it straight back as the tool result (no CODAP round-trip) so the
+        // tool_use is still answered and the model can recover in this same turn.
+        if (data.request?.status === "error") {
+          self.addDbgMsg("Tool call could not be prepared", formatJsonMessage(data.request));
+          return JSON.stringify(data.request);
+        }
+
         if (data.type === "create_request") {
           const { action, resource, values } = data.request;
           const request = { action, resource, values };

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,6 +153,10 @@ export interface IToolCallData {
     resource: string;
     graphID?: string;
     values?: any;
+    // Present when the server could not prepare the tool call; the client forwards
+    // this straight back as the tool result instead of calling CODAP.
+    status?: string;
+    error?: string;
   };
   tool_call_id: string;
   type: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,17 +147,23 @@ export interface IGraphAttrData {
   y2Axis?: Record<string, any>;
 }
 
+export interface IToolRequest {
+  action: string;
+  resource: string;
+  graphID?: string;
+  values?: any;
+}
+
+// Returned when the server could not prepare the tool call (e.g. the model's
+// arguments failed the tool schema). The client forwards this straight back as
+// the tool result instead of calling CODAP, so the tool_use is still answered.
+export interface IToolRequestError {
+  status: "error";
+  error: string;
+}
+
 export interface IToolCallData {
-  request: {
-    action: string;
-    resource: string;
-    graphID?: string;
-    values?: any;
-    // Present when the server could not prepare the tool call; the client forwards
-    // this straight back as the tool result instead of calling CODAP.
-    status?: string;
-    error?: string;
-  };
+  request: IToolRequest | IToolRequestError;
   tool_call_id: string;
   type: string;
 }


### PR DESCRIPTION
## DAVAI-56: a failed tool call no longer breaks the rest of the conversation

### The bug
When a tool call failed (e.g. the user says **"select no data" / "deselect all data"** → the model's args fail the tool's JSON schema → debug log shows *"Received tool input did not match expected schema"*, user sees *"Sorry, I ran into an error…"*), **every subsequent LLM call in that thread then failed** with the Anthropic 400:

> `messages.2: tool_use ids were found without tool_result blocks immediately after: toolu_… Each tool_use block must have a corresponding tool_result block in the next message.`

### Root cause
When the model emits a `tool_use`, LangGraph commits that `AIMessage` to the Postgres checkpoint **during `.invoke()`**. The failure happened *after* that, in `toolCallResponse` → `definedTool.invoke()` (which **threw** on schema mismatch), so the job was marked `error` and the client showed "Sorry…" **without ever entering the `requires_action` tool loop** — no `tool_result` was ever submitted. The orphaned `tool_use` then poisoned every later turn.

### The fix (two layers, server-side)
1. **Graceful tool errors (prevention).** `toolCallResponse` no longer throws — on any failure (schema mismatch, non-JSON result, unknown tool) it returns an *answerable* `requires_action` response carrying `request: { status: "error", error }`. The client (`processToolCall`) detects `request.status === "error"` and forwards it straight back as the tool result (no CODAP round-trip), so the `tool_use` is answered in-turn and the model can recover.
2. **Server self-heal (safety net + repair).** Before every model call, the job processor reads persisted thread state and **prepends synthetic error `tool_result` messages** for any `tool_use` that was never answered. Because the LangGraph reducer is `(x, y) => x.concat(y)`, prepended repairs land immediately after the orphaned `tool_use` at the tail of history. This repairs threads **already broken in production** and defends against *any* future cause (client crash, polling timeout, and the latent bug where `buildResponse` forwarded only `toolCalls[0]` and silently dropped extras).

### Changes
- `sam-server/src/utils/tool-utils.ts` — `getUnansweredToolCallIds`, `buildToolRepairMessages`, and graceful `toolCallResponse` (+ tests).
- `sam-server/src/handlers/job-processor.ts` — self-heal before `app.invoke()` (single `getLangApp()`, `getState` wrapped in try/catch, repairs prepended, excludes the id a tool-job is itself answering).
- `src/models/assistant-model.ts` + `src/types.ts` — client forwards server tool-error payloads back as tool results.

### Testing
- Server suite **47/47**, client suite **234/234**, lint + production build clean.
- Each task spec+quality reviewed; final whole-branch review verified the Anthropic message-coalescing assumption against `@langchain/anthropic@1.5.0`, plus idempotency and ordering for both message and tool jobs.
- **Manually verified on staging-a**: "select no data" recovers in-turn (no dead error), then "make a graph" succeeds — no 400.

### Deploy notes
- The `/sam-server` backend is **deployed manually** (CI deploys only the client). This is already on **staging-a**; **production still runs the old code until a prod `sam deploy`**. Ship client + server together (both are individually backward-tolerant).
- **Follow-up (out of scope):** `trimMessages` in `llm-utils.ts` can still split a `tool_use`/`tool_result` pair on threads over the ~100k-token limit — pre-existing, untouched here. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
