### PR TITLE
DAVAI-118: Stream LLM output to text, screen reader, and read-aloud

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ Generated from source comments and MST runtime introspection. Do not edit manual
 | sonify.scatterPlotContinuousType        | enum     | "lsrl"                                      |
 | sonify.scatterPlotEachDot               | boolean  | true                                        |
 | sonify.synthReleaseTime                 | number   | 0.24                                        |
+| streamResponses                         | boolean  | true                                        |
 
 ## `dimensions.height`
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,19 @@
 const transpileModules = [
   "react-markdown",
+  // remark-gfm (GFM tables/strikethrough/etc.) and its ESM dependency tree. Most
+  // entries match by prefix (no trailing slash), so e.g. "mdast-util-gfm" also covers
+  // "mdast-util-gfm-table" and "micromark-extension-gfm" covers its sub-extensions.
+  "remark-gfm",
+  "micromark-extension-gfm",
+  "mdast-util-gfm",
+  "mdast-util-to-markdown",
+  "mdast-util-find-and-replace",
+  "mdast-util-phrasing",
+  "markdown-table",
+  "longest-streak",
+  "zwitch",
+  "ccount",
+  "escape-string-regexp",
   "tone",
   "bail",
   "comma-separated-tokens",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^9.0.1",
+        "remark-gfm": "^4.0.1",
         "remove-markdown": "^0.6.0",
         "tone": "^15.0.4",
         "tslib": "^2.5.2"
@@ -13849,6 +13850,16 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/mathjs": {
       "version": "3.20.2",
       "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-3.20.2.tgz",
@@ -13886,6 +13897,34 @@
         "node": "*"
       }
     },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
@@ -13904,6 +13943,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -14190,6 +14330,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -17047,6 +17308,24 @@
         "node": ">=4"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -17074,6 +17353,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^9.0.1",
+    "remark-gfm": "^4.0.1",
     "remove-markdown": "^0.6.0",
     "tone": "^15.0.4",
     "tslib": "^2.5.2"

--- a/sam-server/src/handlers/job-processor.ts
+++ b/sam-server/src/handlers/job-processor.ts
@@ -195,6 +195,13 @@ export const handler = async (event: SQSEvent): Promise<void> => {
         throw streamError;
       }
 
+      // Flush any trailing text not yet written, so user-facing text that precedes a
+      // tool call (a mixed text+tool turn, whose final write is requires_action and
+      // carries no text) reaches the client complete.
+      if (!controller.signal.aborted && accumulated.length > lastWrittenLength) {
+        await writePartial();
+      }
+
       if (controller.signal.aborted) {
         console.log(`Job ${messageId} aborted during streaming`);
         // The loop can exit via the cooperative `break` without the iterator

--- a/sam-server/src/handlers/job-processor.ts
+++ b/sam-server/src/handlers/job-processor.ts
@@ -3,7 +3,7 @@ import { Pool } from "pg";
 import { HumanMessage, ToolMessage } from "@langchain/core/messages";
 import { getLangApp } from "../utils/llm-utils";
 import { buildToolRepairMessages, extractToolCalls, toolCallResponse } from "../utils/tool-utils";
-import { messageTextToString, shouldFlush, isAbortError } from "../utils/stream-utils";
+import { messageTextToString, shouldFlush, isAbortError, withAccumulatedResponse } from "../utils/stream-utils";
 import { Job, ToolJob, MessageJob } from "../types";
 import { getLangSmithKey } from "../utils/env-utils";
 
@@ -216,9 +216,14 @@ export const handler = async (event: SQSEvent): Promise<void> => {
       } else {
         // Prefer the final graph state's message (preserves tool_calls); fall back to
         // the accumulated text if no "values" snapshot arrived.
-        const output = finalMessage
+        const built = finalMessage
           ? await buildResponse(finalMessage)
           : { response: messageTextToString(accumulated) };
+        // A mixed text+tool turn ends with a requires_action payload that carries no
+        // response text; attach the accumulated pre-tool text so the client can finalize
+        // it regardless of streaming display or poll timing (the prior streaming updates
+        // are overwritten by this terminal write).
+        const output = withAccumulatedResponse(built, messageTextToString(accumulated));
         // Guard the terminal write too, so a late completion can't clobber a cancel.
         await pool.query(
           `UPDATE jobs SET status='completed', output=$1, updated_at=NOW()

--- a/sam-server/src/handlers/job-processor.ts
+++ b/sam-server/src/handlers/job-processor.ts
@@ -3,6 +3,7 @@ import { Pool } from "pg";
 import { HumanMessage, ToolMessage } from "@langchain/core/messages";
 import { getLangApp } from "../utils/llm-utils";
 import { buildToolRepairMessages, extractToolCalls, toolCallResponse } from "../utils/tool-utils";
+import { messageTextToString, shouldFlush, isAbortError } from "../utils/stream-utils";
 import { Job, ToolJob, MessageJob } from "../types";
 import { getLangSmithKey } from "../utils/env-utils";
 
@@ -139,25 +140,71 @@ export const handler = async (event: SQSEvent): Promise<void> => {
         messages.push(new HumanMessage({ content: messageJob.input.message }));
       }
 
-      // Process with LangGraph
-      const result = await app.invoke(
-        { messages, dataContexts, graphs },
-        config
-      );
+      // Stream the model. "messages" surfaces token chunks (user-facing text only);
+      // "values" yields the final graph state, whose last message we hand to
+      // buildResponse (preserving tool_calls/content-block structure).
+      let accumulated = "";
+      let lastWrittenLength = 0;
+      let finalMessage: any;
+
+      const writePartial = async () => {
+        const text = messageTextToString(accumulated);
+        // Guard on cancelled=false so a cancel landing between flushes is not resurrected.
+        await pool.query(
+          `UPDATE jobs SET status='streaming', output=$1, updated_at=NOW()
+           WHERE message_id=$2 AND cancelled=false`,
+          [{ response: text }, messageId]
+        );
+        lastWrittenLength = accumulated.length;
+      };
+
+      try {
+        const stream = await app.stream(
+          { messages, dataContexts, graphs },
+          { ...config, streamMode: ["messages", "values"] }
+        );
+        for await (const [mode, payload] of stream) {
+          if (controller.signal.aborted) break;
+          if (mode === "messages") {
+            // payload is [AIMessageChunk, metadata]; accumulate only text content.
+            const chunkText = messageTextToString((payload as any)[0]?.content);
+            if (chunkText) {
+              accumulated += chunkText;
+              if (shouldFlush(accumulated, lastWrittenLength)) {
+                await writePartial();
+              }
+            }
+          } else if (mode === "values") {
+            const msgs = (payload as any)?.messages;
+            if (Array.isArray(msgs) && msgs.length) finalMessage = msgs[msgs.length - 1];
+          }
+        }
+      } catch (streamError) {
+        if (isAbortError(streamError, controller.signal)) {
+          // User/cancel-initiated abort: leave the job cancelled, not errored.
+          await pool.query(
+            `UPDATE jobs SET status='cancelled', updated_at=NOW()
+             WHERE message_id=$1 AND status <> 'completed'`,
+            [messageId]
+          );
+          continue;
+        }
+        throw streamError;
+      }
 
       if (controller.signal.aborted) {
-        console.log(`Job ${messageId} aborted before completion`);
+        console.log(`Job ${messageId} aborted during streaming`);
       } else {
-
-        const lastMessage = result.messages[result.messages.length - 1];
-        const output = await buildResponse(lastMessage);
-
-        // Update job status
+        // Prefer the final graph state's message (preserves tool_calls); fall back to
+        // the accumulated text if no "values" snapshot arrived.
+        const output = finalMessage
+          ? await buildResponse(finalMessage)
+          : { response: messageTextToString(accumulated) };
+        // Guard the terminal write too, so a late completion can't clobber a cancel.
         await pool.query(
-          `UPDATE jobs
-          SET status = $1, output = $2, updated_at = NOW()
-          WHERE message_id = $3`,
-          ["completed", output, messageId]
+          `UPDATE jobs SET status='completed', output=$1, updated_at=NOW()
+           WHERE message_id=$2 AND cancelled=false`,
+          [output, messageId]
         );
       }
     } catch (error) {

--- a/sam-server/src/handlers/job-processor.ts
+++ b/sam-server/src/handlers/job-processor.ts
@@ -194,6 +194,15 @@ export const handler = async (event: SQSEvent): Promise<void> => {
 
       if (controller.signal.aborted) {
         console.log(`Job ${messageId} aborted during streaming`);
+        // The loop can exit via the cooperative `break` without the iterator
+        // throwing, so mirror the catch-path cancelled write here. Guard on
+        // status <> 'completed' (NOT cancelled=false): cancel.ts has already set
+        // cancelled=true, so a cancelled=false guard would match zero rows.
+        await pool.query(
+          `UPDATE jobs SET status='cancelled', updated_at=NOW()
+           WHERE message_id=$1 AND status <> 'completed'`,
+          [messageId]
+        );
       } else {
         // Prefer the final graph state's message (preserves tool_calls); fall back to
         // the accumulated text if no "values" snapshot arrived.

--- a/sam-server/src/handlers/job-processor.ts
+++ b/sam-server/src/handlers/job-processor.ts
@@ -16,7 +16,10 @@ const buildResponse = async (message: any) => {
   if (toolCalls?.[0]) {
     return await toolCallResponse(toolCalls[0]);
   }
-  return { response: message.content };
+  // Coerce to a string: app.stream's assembled final message can carry an
+  // Anthropic content-block array, which the client renders via react-markdown
+  // (string-only). Mirrors the streaming partials, which already coerce.
+  return { response: messageTextToString(message.content) };
 };
 
 // Track currently running jobs

--- a/sam-server/src/utils/stream-utils.test.ts
+++ b/sam-server/src/utils/stream-utils.test.ts
@@ -1,4 +1,4 @@
-import { messageTextToString, shouldFlush, isAbortError } from "./stream-utils";
+import { messageTextToString, shouldFlush, isAbortError, withAccumulatedResponse } from "./stream-utils";
 
 describe("messageTextToString", () => {
   it("returns a string unchanged", () => {
@@ -45,5 +45,22 @@ describe("isAbortError", () => {
   it("is false for an ordinary error with an un-aborted signal", () => {
     const c = new AbortController();
     expect(isAbortError(new Error("400 bad request"), c.signal)).toBe(false);
+  });
+});
+
+describe("withAccumulatedResponse", () => {
+  it("attaches accumulated text to a tool-call payload that carries no response", () => {
+    const toolOutput = { request: { foo: 1 }, status: "requires_action", tool_call_id: "t1", type: "x" };
+    expect(withAccumulatedResponse(toolOutput, "Pre-tool text.")).toEqual({
+      ...toolOutput, response: "Pre-tool text."
+    });
+  });
+  it("does not overwrite an existing response (a plain text completion)", () => {
+    const out = { response: "Full answer." };
+    expect(withAccumulatedResponse(out, "ignored")).toEqual({ response: "Full answer." });
+  });
+  it("returns the payload unchanged when there is no accumulated text", () => {
+    const out = { status: "requires_action", tool_call_id: "t1" };
+    expect(withAccumulatedResponse(out, "")).toBe(out);
   });
 });

--- a/sam-server/src/utils/stream-utils.test.ts
+++ b/sam-server/src/utils/stream-utils.test.ts
@@ -1,0 +1,49 @@
+import { messageTextToString, shouldFlush, isAbortError } from "./stream-utils";
+
+describe("messageTextToString", () => {
+  it("returns a string unchanged", () => {
+    expect(messageTextToString("hello")).toBe("hello");
+  });
+  it("joins text blocks from a content-block array and drops non-text", () => {
+    const content = [{ type: "text", text: "a" }, { type: "tool_use", id: "x" }, { type: "text", text: "b" }];
+    expect(messageTextToString(content)).toBe("ab");
+  });
+  it("returns empty string for null/other", () => {
+    expect(messageTextToString(null)).toBe("");
+    expect(messageTextToString(42)).toBe("");
+  });
+});
+
+describe("shouldFlush", () => {
+  it("flushes when a sentence ends since last write", () => {
+    expect(shouldFlush("Hello world.", 0)).toBe(true);
+  });
+  it("flushes on a newline (e.g. a list item or code line)", () => {
+    expect(shouldFlush("- item one\n", 0)).toBe(true);
+  });
+  it("does not flush mid-sentence below the size cap", () => {
+    expect(shouldFlush("Hello wor", 0)).toBe(false);
+  });
+  it("only considers text added since lastWrittenLength", () => {
+    expect(shouldFlush("Done. and more", "Done.".length)).toBe(false);
+  });
+  it("flushes a long unpunctuated run at the size cap", () => {
+    expect(shouldFlush("x".repeat(200), 0)).toBe(true);
+  });
+});
+
+describe("isAbortError", () => {
+  it("is true when the signal is aborted", () => {
+    const c = new AbortController(); c.abort();
+    expect(isAbortError(new Error("boom"), c.signal)).toBe(true);
+  });
+  it("is true for an abort-named error even if signal not aborted", () => {
+    const c = new AbortController();
+    const e = new Error("the operation was aborted"); (e as any).name = "AbortError";
+    expect(isAbortError(e, c.signal)).toBe(true);
+  });
+  it("is false for an ordinary error with an un-aborted signal", () => {
+    const c = new AbortController();
+    expect(isAbortError(new Error("400 bad request"), c.signal)).toBe(false);
+  });
+});

--- a/sam-server/src/utils/stream-utils.ts
+++ b/sam-server/src/utils/stream-utils.ts
@@ -22,6 +22,22 @@ export function shouldFlush(fullText: string, lastWrittenLength: number): boolea
   return FLUSH_BOUNDARY.test(added);
 }
 
+// For a mixed text+tool turn, the terminal tool-call payload (requires_action) carries
+// no `response` text, but the model may have emitted user-facing text before the tool
+// call. Attach that accumulated text so the client can finalize it even if it never
+// polled a transient streaming update (streaming display off, or text + tool call landed
+// within one poll interval). A plain text completion already has `response` and is left
+// untouched.
+export function withAccumulatedResponse(
+  output: Record<string, unknown>,
+  accumulated: string
+): Record<string, unknown> {
+  if (typeof output.response !== "string" && accumulated) {
+    return { ...output, response: accumulated };
+  }
+  return output;
+}
+
 // Distinguish a user/cancel-initiated abort (don't mark the job "error") from a
 // real failure. An aborted in-node invoke throws under app.stream().
 export function isAbortError(error: unknown, signal: AbortSignal): boolean {

--- a/sam-server/src/utils/stream-utils.ts
+++ b/sam-server/src/utils/stream-utils.ts
@@ -1,0 +1,33 @@
+// Coerce an LLM message `content` to plain text. Anthropic content can be a
+// content-block array; we keep only text blocks so the client always diffs a string.
+export function messageTextToString(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((block: any) => (block && block.type === "text" && typeof block.text === "string" ? block.text : ""))
+      .join("");
+  }
+  return "";
+}
+
+const FLUSH_BOUNDARY = /[.!?\n]/;
+const MAX_UNWRITTEN = 200;
+
+// Decide whether to write a streaming partial yet: flush on a sentence end or
+// newline in the newly-added text, or once an unpunctuated run gets long.
+export function shouldFlush(fullText: string, lastWrittenLength: number): boolean {
+  const added = fullText.slice(lastWrittenLength);
+  if (added.length === 0) return false;
+  if (added.length >= MAX_UNWRITTEN) return true;
+  return FLUSH_BOUNDARY.test(added);
+}
+
+// Distinguish a user/cancel-initiated abort (don't mark the job "error") from a
+// real failure. An aborted in-node invoke throws under app.stream().
+export function isAbortError(error: unknown, signal: AbortSignal): boolean {
+  if (signal.aborted) return true;
+  const name = (error as any)?.name;
+  const message = (error as any)?.message;
+  return (typeof name === "string" && /abort/i.test(name)) ||
+         (typeof message === "string" && /abort/i.test(message));
+}

--- a/src/app-config.json
+++ b/src/app-config.json
@@ -10,6 +10,7 @@
   "playProcessingTone": false,
   "playbackSpeed": 1,
   "readAloudEnabled": false,
+  "streamResponses": true,
   "llmId": "{\"id\":\"claude-haiku-4-5\",\"provider\":\"Anthropic\"}",
   "llmList": [
     {

--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -1,6 +1,7 @@
 @use "./vars.scss" as *;
 
 .App {
+  position: relative; // positioning context for the floating speaking indicator
   background-color: white;
   color: rgb(110,109,95);
   text-align: center;

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -6,10 +6,23 @@ import { mockAppConfig } from "../test-utils/mock-app-config";
 import { MockAppConfigProvider } from "../test-utils/app-config-provider";
 import { ShortcutsServiceProvider } from "../contexts/shortcuts-service-context";
 import { AriaLiveProvider } from "../contexts/aria-live-context";
-import { SpeechServiceProvider } from "../contexts/speech-service-context";
+import { SpeechServiceProvider, SpeechServiceContext } from "../contexts/speech-service-context";
+import { ISpeechService } from "../services/speech-service";
 import { mockTransportManager } from "../test-utils/mock-transport-manager";
 import { setupMockSpeechSynthesis, cleanupMockSpeechSynthesis } from "../test-utils/mock-speech-synthesis";
 import { DAVAI_SPEAKER } from "../constants";
+
+const createMockSpeechService = (): ISpeechService => ({
+  speak: jest.fn(),
+  stopSpeech: jest.fn(),
+  stopAndSuppress: jest.fn(),
+  enqueue: jest.fn(),
+  speakIfIdle: jest.fn(),
+  resumeSpeech: jest.fn(),
+  isSpeaking: jest.fn(() => false),
+  dispose: jest.fn(),
+  onSpeakingChange: jest.fn(() => jest.fn()),
+});
 
 // Mutable so individual tests can vary the busy/streaming state the App reads.
 const mockAssistantStore: any = {
@@ -129,5 +142,26 @@ describe("test load app", () => {
     // stopSpeech() cancels the browser speech synthesis, so a fresh question interrupts
     // the previous answer's still-playing audio.
     expect(window.speechSynthesis.cancel).toHaveBeenCalled();
+  });
+
+  it("clears Escape/Stop suppression on submit so the next Processing message is read", () => {
+    const mockService = createMockSpeechService();
+    render(
+      <MockAppConfigProvider>
+        <ShortcutsServiceProvider>
+          <AriaLiveProvider>
+            <SpeechServiceContext.Provider value={{ speechService: mockService, isSpeaking: false, currentSpeechText: null }}>
+              <App />
+            </SpeechServiceContext.Provider>
+          </AriaLiveProvider>
+        </ShortcutsServiceProvider>
+      </MockAppConfigProvider>
+    );
+
+    fireEvent.change(screen.getByTestId("chat-input-textarea"), { target: { value: "Question" } });
+    fireEvent.click(screen.getByTestId("chat-input-send"));
+
+    expect(mockService.stopSpeech).toHaveBeenCalled();
+    expect(mockService.resumeSpeech).toHaveBeenCalled(); // lifts a prior Escape/Stop suppression
   });
 });

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -9,6 +9,7 @@ import { AriaLiveProvider } from "../contexts/aria-live-context";
 import { SpeechServiceProvider } from "../contexts/speech-service-context";
 import { mockTransportManager } from "../test-utils/mock-transport-manager";
 import { setupMockSpeechSynthesis, cleanupMockSpeechSynthesis } from "../test-utils/mock-speech-synthesis";
+import { DAVAI_SPEAKER } from "../constants";
 
 // Mutable so individual tests can vary the busy/streaming state the App reads.
 const mockAssistantStore: any = {
@@ -65,12 +66,15 @@ const renderApp = () =>
   );
 
 describe("test load app", () => {
+  window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
   beforeEach(() => {
     setupMockSpeechSynthesis();
     mockAssistantStore.threadId = "thread-1";
     mockAssistantStore.showLoadingIndicator = false;
     mockAssistantStore.isLoadingResponse = false;
     mockAssistantStore.isResponding = false;
+    mockAssistantStore.transcriptStore = { messages: [], addMessage: jest.fn() };
   });
 
   afterEach(() => {
@@ -96,5 +100,23 @@ describe("test load app", () => {
 
     expect(screen.getByTestId("chat-input-cancel")).toBeInTheDocument();
     expect(screen.queryByTestId("chat-input-send")).not.toBeInTheDocument();
+  });
+
+  it("announces a finalized DAVAI response, voicing bullets as 'bullet'", async () => {
+    // A non-streamed DAVAI response that is the last transcript row should be announced
+    // via the assertive aria-live region, with the bullet marker voiced as the word.
+    mockAssistantStore.transcriptStore = {
+      messages: [
+        {
+          speaker: DAVAI_SPEAKER, isStreaming: false, id: "1", timestamp: "t",
+          messageContent: { content: "- Apple" }, plainTextContent: "- Apple"
+        }
+      ],
+      addMessage: jest.fn(),
+    };
+
+    renderApp();
+
+    expect(await screen.findByText("bullet Apple")).toBeInTheDocument();
   });
 });

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -1,6 +1,6 @@
 import "openai/shims/node";
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { App } from "./App";
 import { mockAppConfig } from "../test-utils/mock-app-config";
 import { MockAppConfigProvider } from "../test-utils/app-config-provider";
@@ -118,5 +118,16 @@ describe("test load app", () => {
     renderApp();
 
     expect(await screen.findByText("bullet Apple")).toBeInTheDocument();
+  });
+
+  it("stops any in-progress speech when a new message is submitted", () => {
+    renderApp();
+
+    fireEvent.change(screen.getByTestId("chat-input-textarea"), { target: { value: "Another question" } });
+    fireEvent.click(screen.getByTestId("chat-input-send"));
+
+    // stopSpeech() cancels the browser speech synthesis, so a fresh question interrupts
+    // the previous answer's still-playing audio.
+    expect(window.speechSynthesis.cancel).toHaveBeenCalled();
   });
 });

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -10,15 +10,24 @@ import { SpeechServiceProvider } from "../contexts/speech-service-context";
 import { mockTransportManager } from "../test-utils/mock-transport-manager";
 import { setupMockSpeechSynthesis, cleanupMockSpeechSynthesis } from "../test-utils/mock-speech-synthesis";
 
+// Mutable so individual tests can vary the busy/streaming state the App reads.
+const mockAssistantStore: any = {
+  initializeAssistant: jest.fn(),
+  updateDataContexts: jest.fn(),
+  updateGraphs: jest.fn(),
+  handleCancel: jest.fn(),
+  handleMessageSubmit: jest.fn(),
+  setStreamEnabled: jest.fn(),
+  transcriptStore: { messages: [], addMessage: jest.fn() },
+  threadId: "thread-1",
+  showLoadingIndicator: false,
+  isLoadingResponse: false,
+  isResponding: false,
+};
+
 jest.mock("../contexts/root-store-context", () => ({
   useRootStore: jest.fn(() => ({
-    assistantStore: {
-      initializeAssistant: jest.fn(),
-      transcriptStore: {
-        messages: [],
-        addMessage: jest.fn(),
-      }
-    },
+    assistantStore: mockAssistantStore,
     sonificationStore: {
       selectedGraph: { id: "graph1", name: "Graph 1" },
       setGraphs: jest.fn(),
@@ -42,9 +51,26 @@ jest.mock("../models/app-config-model", () => ({
   }
 }));
 
+const renderApp = () =>
+  render(
+    <MockAppConfigProvider>
+      <ShortcutsServiceProvider>
+        <AriaLiveProvider>
+          <SpeechServiceProvider>
+            <App />
+          </SpeechServiceProvider>
+        </AriaLiveProvider>
+      </ShortcutsServiceProvider>
+    </MockAppConfigProvider>
+  );
+
 describe("test load app", () => {
   beforeEach(() => {
     setupMockSpeechSynthesis();
+    mockAssistantStore.threadId = "thread-1";
+    mockAssistantStore.showLoadingIndicator = false;
+    mockAssistantStore.isLoadingResponse = false;
+    mockAssistantStore.isResponding = false;
   });
 
   afterEach(() => {
@@ -52,19 +78,23 @@ describe("test load app", () => {
   });
 
   it("renders without crashing", () => {
-    render(
-      <MockAppConfigProvider>
-        <ShortcutsServiceProvider>
-          <AriaLiveProvider>
-            <SpeechServiceProvider>
-              <App />
-            </SpeechServiceProvider>
-          </AriaLiveProvider>
-        </ShortcutsServiceProvider>
-      </MockAppConfigProvider>
-    );
+    renderApp();
     expect(screen.getByText("DAVAI")).toBeDefined();
     expect(screen.getByTestId("chat-transcript")).toBeDefined();
     expect(screen.getByTestId("chat-input")).toBeDefined();
+  });
+
+  it("shows the Cancel button (not Send) while a response is streaming", () => {
+    // Mirrors streaming after the first chunk: the "Processing" indicator is cleared
+    // (showLoadingIndicator false) but a response is still in flight, so the chat input
+    // must stay busy with a Cancel button rather than re-enabling Send.
+    mockAssistantStore.isLoadingResponse = true;
+    mockAssistantStore.showLoadingIndicator = false;
+    mockAssistantStore.isResponding = true;
+
+    renderApp();
+
+    expect(screen.getByTestId("chat-input-cancel")).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-input-send")).not.toBeInTheDocument();
   });
 });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -181,6 +181,7 @@ export const App = observer(() => {
     if (appConfig.isAssistantMocked) {
       assistantStore.handleMessageSubmitMockAssistant();
     } else {
+      assistantStore.setStreamEnabled(appConfig.streamResponses);
       await assistantStore.handleMessageSubmit(messageText);
     }
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -198,7 +198,7 @@ export const App = observer(() => {
           <abbr title="Data Analysis through Voice and Artificial Intelligence">DAVAI</abbr>
           <span>(Data Analysis through Voice and Artificial Intelligence)</span>
         </h1>
-        <SpeakingIndicator />
+        <SpeakingIndicator isProcessing={assistantStore.showLoadingIndicator} />
       </header>
       <ChatTranscriptComponent
         chatTranscript={transcriptStore}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,6 +7,7 @@ import { useAppConfigContext } from "../contexts/app-config-context";
 import { useRootStore } from "../contexts/root-store-context";
 import { useAriaLive } from "../contexts/aria-live-context";
 import { useShortcutsService } from "../contexts/shortcuts-service-context";
+import { useSpeechService } from "../contexts/speech-service-context";
 import { ChatInputComponent } from "./chat-input";
 import { ChatTranscriptComponent } from "./chat-transcript";
 import { DAVAI_SPEAKER, LOADING_NOTE, USER_SPEAKER, notificationsToIgnore } from "../constants";
@@ -29,6 +30,7 @@ const kVersion = process.env.DAVAI_VERSION || "local-build";
 export const App = observer(() => {
   const appConfig = useAppConfigContext();
   const shortcutsService = useShortcutsService();
+  const speechService = useSpeechService();
   const { ariaLiveText, setAriaLiveText } = useAriaLive();
   const { assistantStore, sonificationStore, transportManager } = useRootStore();
   const { playProcessingTone } = appConfig;
@@ -179,6 +181,10 @@ export const App = observer(() => {
 
   const handleChatInputSubmit = async (messageText: string) => {
     Tone.start();
+    // A new question interrupts the previous answer's still-playing audio. (The input is
+    // disabled while a response is in flight, so this only stops a finished turn's
+    // lingering speech, never an in-progress one.)
+    speechService.stopSpeech();
     transcriptStore.addMessage(USER_SPEAKER, {content: messageText});
 
     if (appConfig.isAssistantMocked) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -18,6 +18,7 @@ import { isGraphSonifiable } from "../utils/graph-sonification-utils";
 import { ICODAPGraph } from "../types";
 import { GraphSonificationScheduler } from "../models/graph-sonification-scheduler";
 import { SpeakingIndicator } from "./speaking-indicator";
+import { StreamingAnnouncer } from "./streaming-announcer";
 
 import "./App.scss";
 
@@ -149,7 +150,7 @@ export const App = observer(() => {
     const { messages } = transcriptStore;
     if (transcriptStore.messages.length > 0) {
       const lastMessage = messages[messages.length - 1];
-      if (lastMessage.speaker === DAVAI_SPEAKER) {
+      if (lastMessage.speaker === DAVAI_SPEAKER && !lastMessage.isStreaming) {
         setAriaLiveText(lastMessage.plainTextContent);
       }
     }
@@ -202,6 +203,7 @@ export const App = observer(() => {
         chatTranscript={transcriptStore}
         isLoading={assistantStore.showLoadingIndicator}
       />
+      <StreamingAnnouncer transcript={transcriptStore} />
       <ChatInputComponent
         disabled={(!assistantStore.threadId && !appConfig.isAssistantMocked) || assistantStore.showLoadingIndicator}
         isLoading={assistantStore.showLoadingIndicator}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -206,8 +206,8 @@ export const App = observer(() => {
       />
       <StreamingAnnouncer transcript={transcriptStore} />
       <ChatInputComponent
-        disabled={(!assistantStore.threadId && !appConfig.isAssistantMocked) || assistantStore.showLoadingIndicator}
-        isLoading={assistantStore.showLoadingIndicator}
+        disabled={(!assistantStore.threadId && !appConfig.isAssistantMocked) || assistantStore.isResponding}
+        isLoading={assistantStore.isResponding}
         onCancel={handleCancel}
         onSubmit={handleChatInputSubmit}
       />

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -19,6 +19,7 @@ import { ICODAPGraph } from "../types";
 import { GraphSonificationScheduler } from "../models/graph-sonification-scheduler";
 import { SpeakingIndicator } from "./speaking-indicator";
 import { StreamingAnnouncer } from "./streaming-announcer";
+import { forSpeechMultiline } from "../utils/speech-text";
 
 import "./App.scss";
 
@@ -151,7 +152,9 @@ export const App = observer(() => {
     if (transcriptStore.messages.length > 0) {
       const lastMessage = messages[messages.length - 1];
       if (lastMessage.speaker === DAVAI_SPEAKER && !lastMessage.isStreaming) {
-        setAriaLiveText(lastMessage.plainTextContent);
+        // Strip markdown and voice list/table structure (bullets -> "bullet", tables
+        // linearized) for the spoken/announced text — same handling as streamed chunks.
+        setAriaLiveText(forSpeechMultiline(lastMessage.messageContent.content));
       }
     }
   }, [transcriptStore, transcriptStore.messages.length, setAriaLiveText]);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -183,8 +183,10 @@ export const App = observer(() => {
     Tone.start();
     // A new question interrupts the previous answer's still-playing audio. (The input is
     // disabled while a response is in flight, so this only stops a finished turn's
-    // lingering speech, never an in-progress one.)
+    // lingering speech, never an in-progress one.) resumeSpeech clears any lingering
+    // Escape/Stop suppression so this turn's "Processing" message and reply are read.
     speechService.stopSpeech();
+    speechService.resumeSpeech();
     transcriptStore.addMessage(USER_SPEAKER, {content: messageText});
 
     if (appConfig.isAssistantMocked) {

--- a/src/components/chat-transcript-message.test.tsx
+++ b/src/components/chat-transcript-message.test.tsx
@@ -1,0 +1,17 @@
+import { toMarkdownString } from "./chat-transcript-message";
+
+describe("toMarkdownString", () => {
+  it("passes a string through unchanged", () => {
+    expect(toMarkdownString("hello world")).toBe("hello world");
+  });
+
+  it("extracts and joins text from an Anthropic content-block array", () => {
+    const content = [{ type: "text", text: "a" }, { type: "tool_use", id: "x" }, { type: "text", text: "b" }];
+    expect(toMarkdownString(content)).toBe("ab");
+  });
+
+  it("coerces nullish content to an empty string (never crashes react-markdown)", () => {
+    expect(toMarkdownString(null)).toBe("");
+    expect(toMarkdownString(undefined)).toBe("");
+  });
+});

--- a/src/components/chat-transcript-message.tsx
+++ b/src/components/chat-transcript-message.tsx
@@ -9,6 +9,17 @@ interface IProps {
   showDebugLog: boolean;
 }
 
+// react-markdown requires a string for `children`. Coerce defensively so a
+// non-string content (e.g. an Anthropic content-block array) can never hard-crash
+// the whole transcript; extract text blocks when given an array.
+export function toMarkdownString(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map((block: any) => (block && typeof block.text === "string" ? block.text : "")).join("");
+  }
+  return content == null ? "" : String(content);
+}
+
 export const ChatTranscriptMessage = ({message, showDebugLog}: IProps) => {
   const { setAriaLiveText } = useAriaLive();
   const { speaker, messageContent } = message;
@@ -68,7 +79,7 @@ export const ChatTranscriptMessage = ({message, showDebugLog}: IProps) => {
       >
         {speaker === DEBUG_SPEAKER ?
           renderDebugPreview() :
-          <Markdown>{messageContent.content}</Markdown>
+          <Markdown>{toMarkdownString(messageContent.content)}</Markdown>
         }
       </div>
     </div>

--- a/src/components/chat-transcript-message.tsx
+++ b/src/components/chat-transcript-message.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { DEBUG_SPEAKER } from "../constants";
 import { ChatMessage } from "../types";
 import { useAriaLive } from "../contexts/aria-live-context";
@@ -79,7 +80,7 @@ export const ChatTranscriptMessage = ({message, showDebugLog}: IProps) => {
       >
         {speaker === DEBUG_SPEAKER ?
           renderDebugPreview() :
-          <Markdown>{toMarkdownString(messageContent.content)}</Markdown>
+          <Markdown remarkPlugins={[remarkGfm]}>{toMarkdownString(messageContent.content)}</Markdown>
         }
       </div>
     </div>

--- a/src/components/chat-transcript.scss
+++ b/src/components/chat-transcript.scss
@@ -49,6 +49,20 @@
       pre {
         font-size: .75rem;
       }
+      // GFM tables (remark-gfm): match the surrounding message font size, not the
+      // browser default which renders noticeably larger.
+      table {
+        font-size: .75rem;
+        line-height: 17px;
+        border-collapse: collapse;
+        margin: 0 0 10px;
+      }
+      th, td {
+        font-size: .75rem;
+        border: 1px solid $light-teal-1;
+        padding: 2px 6px;
+        text-align: left;
+      }
       .chat-message-content {
         &.user {
           white-space: pre-line; // maintain line breaks

--- a/src/components/chat-transcript.test.tsx
+++ b/src/components/chat-transcript.test.tsx
@@ -4,9 +4,33 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { AppConfigProvider } from "../contexts/app-config-context";
 import { ChatTranscriptComponent } from "./chat-transcript";
 import { ShortcutsServiceProvider } from "../contexts/shortcuts-service-context";
+import { AriaLiveProvider } from "../contexts/aria-live-context";
+import { SpeechServiceProvider } from "../contexts/speech-service-context";
+import { setupMockSpeechSynthesis, cleanupMockSpeechSynthesis } from "../test-utils/mock-speech-synthesis";
+
+const TestProviders = ({ children }: { children: React.ReactNode }) => (
+  <AppConfigProvider>
+    <AriaLiveProvider>
+      <SpeechServiceProvider>
+        <ShortcutsServiceProvider>
+          {children}
+        </ShortcutsServiceProvider>
+      </SpeechServiceProvider>
+    </AriaLiveProvider>
+  </AppConfigProvider>
+);
 
 describe("test chat transcript component", () => {
   window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+  beforeEach(() => {
+    setupMockSpeechSynthesis();
+  });
+
+  afterEach(() => {
+    cleanupMockSpeechSynthesis();
+  });
+
   const chatTranscript = {
     messages: [
       {
@@ -28,11 +52,9 @@ describe("test chat transcript component", () => {
 
   it("renders a chat transcript that lists all chat messages", () => {
     render(
-      <AppConfigProvider>
-        <ShortcutsServiceProvider>
-          <ChatTranscriptComponent chatTranscript={chatTranscript}/>
-        </ShortcutsServiceProvider>
-      </AppConfigProvider>
+      <TestProviders>
+        <ChatTranscriptComponent chatTranscript={chatTranscript}/>
+      </TestProviders>
     );
 
     const transcript = screen.getByTestId("chat-transcript");
@@ -59,11 +81,9 @@ describe("test chat transcript component", () => {
     const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
 
     render(
-      <AppConfigProvider>
-        <ShortcutsServiceProvider>
-          <ChatTranscriptComponent chatTranscript={chatTranscript}/>
-        </ShortcutsServiceProvider>
-      </AppConfigProvider>
+      <TestProviders>
+        <ChatTranscriptComponent chatTranscript={chatTranscript}/>
+      </TestProviders>
     );
 
     fireEvent.click(screen.getByTestId("capture-transcript-button"));
@@ -101,11 +121,9 @@ describe("test chat transcript component", () => {
     };
 
     render(
-      <AppConfigProvider>
-        <ShortcutsServiceProvider>
-          <ChatTranscriptComponent chatTranscript={transcriptWithImage}/>
-        </ShortcutsServiceProvider>
-      </AppConfigProvider>
+      <TestProviders>
+        <ChatTranscriptComponent chatTranscript={transcriptWithImage}/>
+      </TestProviders>
     );
 
     fireEvent.click(screen.getByTestId("capture-transcript-button"));

--- a/src/components/chat-transcript.test.tsx
+++ b/src/components/chat-transcript.test.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import { AppConfigProvider } from "../contexts/app-config-context";
 import { ChatTranscriptComponent } from "./chat-transcript";
 import { ShortcutsServiceProvider } from "../contexts/shortcuts-service-context";
-import { AriaLiveProvider } from "../contexts/aria-live-context";
+import { AriaLiveProvider, useAriaLive } from "../contexts/aria-live-context";
 import { SpeechServiceProvider } from "../contexts/speech-service-context";
 import { setupMockSpeechSynthesis, cleanupMockSpeechSynthesis } from "../test-utils/mock-speech-synthesis";
 
@@ -19,6 +19,12 @@ const TestProviders = ({ children }: { children: React.ReactNode }) => (
     </AriaLiveProvider>
   </AppConfigProvider>
 );
+
+// Renders the shared aria-live text so a test can assert what was announced.
+const AriaLiveDisplay = () => {
+  const { ariaLiveText } = useAriaLive();
+  return <div data-testid="aria-live-display">{ariaLiveText}</div>;
+};
 
 describe("test chat transcript component", () => {
   window.HTMLElement.prototype.scrollIntoView = jest.fn();
@@ -106,6 +112,32 @@ describe("test chat transcript component", () => {
     );
 
     expect(scrollSpy).toHaveBeenCalled();
+  });
+
+  it("replays the last DAVAI message, voicing bullets as 'bullet'", () => {
+    const transcript = {
+      messages: [
+        {
+          speaker: "DAVAI", messageContent: { content: "- Apple" }, plainTextContent: "- Apple",
+          timestamp: "2021-07-01T12:00:00Z", id: "1"
+        }
+      ],
+    };
+    render(
+      <TestProviders>
+        <ChatTranscriptComponent chatTranscript={transcript} />
+        <AriaLiveDisplay />
+      </TestProviders>
+    );
+
+    // Trigger the "replay last DAVAI message" shortcut (Control+Shift+Comma).
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", {
+        code: "Comma", key: ",", ctrlKey: true, shiftKey: true, bubbles: true
+      }));
+    });
+
+    expect(screen.getByTestId("aria-live-display").textContent).toContain("bullet Apple");
   });
 
   it("copies the transcript and downloads it when the capture button is clicked", async () => {

--- a/src/components/chat-transcript.test.tsx
+++ b/src/components/chat-transcript.test.tsx
@@ -73,6 +73,41 @@ describe("test chat transcript component", () => {
     });
   });
 
+  it("keeps autoscrolling as the streaming message grows even when a debug row is last", () => {
+    const scrollSpy = window.HTMLElement.prototype.scrollIntoView as jest.Mock;
+    // A streaming DAVAI message, followed by the DEBUG "Begin response time" row that
+    // ingestStreamChunk adds right after it — so the streaming message is NOT last.
+    const make = (streamContent: string) => ({
+      messages: [
+        {
+          messageContent: { content: streamContent }, speaker: "DAVAI",
+          timestamp: "2021-07-01T12:00:00Z", id: "s1", isStreaming: true, plainTextContent: streamContent
+        },
+        {
+          messageContent: { description: "Begin response time", content: "0.10s" }, speaker: "Debug Log",
+          timestamp: "2021-07-01T12:00:01Z", id: "d1", isStreaming: false, plainTextContent: ""
+        }
+      ]
+    });
+
+    const { rerender } = render(
+      <TestProviders>
+        <ChatTranscriptComponent chatTranscript={make("Hello.")} />
+      </TestProviders>
+    );
+    scrollSpy.mockClear();
+
+    // The streamed message grows (more text appended). messages.length and isLoading
+    // are unchanged, so autoscroll must be driven by the streaming message's length.
+    rerender(
+      <TestProviders>
+        <ChatTranscriptComponent chatTranscript={make("Hello. More text streaming in now.")} />
+      </TestProviders>
+    );
+
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+
   it("copies the transcript and downloads it when the capture button is clicked", async () => {
     const writeText = jest.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText } });

--- a/src/components/chat-transcript.tsx
+++ b/src/components/chat-transcript.tsx
@@ -6,6 +6,7 @@ import { LoadingMessage } from "./loading-message";
 import { useAppConfigContext } from "../contexts/app-config-context";
 import { useShortcutsService } from "../contexts/shortcuts-service-context";
 import { useAriaLive } from "../contexts/aria-live-context";
+import { useSpeechService } from "../contexts/speech-service-context";
 import {
   buildTranscriptCsv,
   buildTranscriptZip,
@@ -27,16 +28,20 @@ export const ChatTranscriptComponent = observer(({chatTranscript, isLoading}: IP
   const shortcutsService = useShortcutsService();
   const chatTranscriptRef = useRef<HTMLDivElement>(null);
   const { setAriaLiveText } = useAriaLive();
+  const speechService = useSpeechService();
   const replayHiddenCharToggleRef = useRef(true);
+
+  const lastMessage = chatTranscript.messages[chatTranscript.messages.length - 1];
+  const streamingLen = lastMessage?.isStreaming ? lastMessage.messageContent.content.length : 0;
 
   useEffect(() => {
     // Autoscroll to the top of the latest message in the transcript.
     const chatTranscriptContainer = chatTranscriptRef.current;
     if (chatTranscriptContainer) {
-      const lastMessage = chatTranscriptContainer.querySelector(".chat-transcript__message:last-of-type");
-      lastMessage?.scrollIntoView({behavior: "smooth", block: "nearest"});
+      const lastTranscriptMessage = chatTranscriptContainer.querySelector(".chat-transcript__message:last-of-type");
+      lastTranscriptMessage?.scrollIntoView({behavior: "smooth", block: "nearest"});
     }
-  }, [chatTranscript.messages.length, isLoading]);
+  }, [chatTranscript.messages.length, isLoading, streamingLen]);
 
   const handleCaptureTranscript = useCallback(async () => {
     const { csv, images } = buildTranscriptCsv(chatTranscript.messages);
@@ -74,6 +79,7 @@ export const ChatTranscriptComponent = observer(({chatTranscript, isLoading}: IP
     // A shortcut to set the last message in the live aria region
     return shortcutsService.registerShortcutHandler("replayLastDavaiMessage", (event) => {
       event.preventDefault();
+      speechService.stopSpeech();
       const lastDavaiMessage = chatTranscript.messages.filter(msg => msg.speaker === "DAVAI").pop();
       // We toggle an invisible character to force the screen reader to read the same message again.
       // We tried to clear the live text, wait, and set it again, but that didn't work
@@ -85,7 +91,7 @@ export const ChatTranscriptComponent = observer(({chatTranscript, isLoading}: IP
         setAriaLiveText(`No previous message from DAVAI to replay.${suffix}`);
       }
     }, { focus: true });
-  }, [chatTranscript.messages, setAriaLiveText, shortcutsService]);
+  }, [chatTranscript.messages, setAriaLiveText, shortcutsService, speechService]);
 
   return (
     <div

--- a/src/components/chat-transcript.tsx
+++ b/src/components/chat-transcript.tsx
@@ -31,8 +31,12 @@ export const ChatTranscriptComponent = observer(({chatTranscript, isLoading}: IP
   const speechService = useSpeechService();
   const replayHiddenCharToggleRef = useRef(true);
 
-  const lastMessage = chatTranscript.messages[chatTranscript.messages.length - 1];
-  const streamingLen = lastMessage?.isStreaming ? lastMessage.messageContent.content.length : 0;
+  // Track the currently-streaming message by its flag, not by position: the first
+  // streamed chunk also appends a DEBUG "Begin response time" row right after it, so the
+  // streaming message is usually not last. Driving autoscroll off its growing length
+  // keeps the transcript scrolled to the newest text as chunks arrive.
+  const streamingMessage = chatTranscript.messages.find((m: any) => m.isStreaming);
+  const streamingLen = streamingMessage ? streamingMessage.messageContent.content.length : 0;
 
   useEffect(() => {
     // Autoscroll to the top of the latest message in the transcript.

--- a/src/components/chat-transcript.tsx
+++ b/src/components/chat-transcript.tsx
@@ -14,6 +14,7 @@ import {
   downloadBlob,
   getTranscriptFilename,
 } from "../utils/transcript-utils";
+import { forSpeechMultiline } from "../utils/speech-text";
 
 import "./chat-transcript.scss";
 
@@ -90,7 +91,9 @@ export const ChatTranscriptComponent = observer(({chatTranscript, isLoading}: IP
       replayHiddenCharToggleRef.current = !replayHiddenCharToggleRef.current;
       const suffix = replayHiddenCharToggleRef.current ? "\u200B" : "\u200C";
       if (lastDavaiMessage) {
-        setAriaLiveText(`Last Message: ${lastDavaiMessage.plainTextContent}${suffix}`);
+        // Voice list/table structure the same way as live announcements (bullets ->
+        // "bullet", tables linearized), instead of the raw markdown in plainTextContent.
+        setAriaLiveText(`Last Message: ${forSpeechMultiline(lastDavaiMessage.messageContent.content)}${suffix}`);
       } else {
         setAriaLiveText(`No previous message from DAVAI to replay.${suffix}`);
       }

--- a/src/components/loading-message.tsx
+++ b/src/components/loading-message.tsx
@@ -1,27 +1,30 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { DAVAI_SPEAKER } from "../constants";
-import { useAriaLive } from "../contexts/aria-live-context";
 import { useAppConfigContext } from "../contexts/app-config-context";
+import { useSpeechService } from "../contexts/speech-service-context";
 
 export const LoadingMessage = observer(function LoadingMessage() {
-  const {setAriaLiveText} = useAriaLive();
   const { playProcessingMessage } = useAppConfigContext();
+  const speechService = useSpeechService();
+  const [announce, setAnnounce] = useState("");
 
   useEffect(() => {
-    if (playProcessingMessage) {
-      setAriaLiveText("Processing");
-      let isAlternate = false;
-
-      const interval = setInterval(() => {
-        // alternate with non-breaking space so screen readers will re-announce the message
-        isAlternate = !isAlternate;
-        const processingMessage = isAlternate ? "Processing\u00a0" : "Processing";
-        setAriaLiveText(processingMessage);
-      }, 4000);
-      return () => clearInterval(interval);
-    }
-  }, [playProcessingMessage, setAriaLiveText]);
+    if (!playProcessingMessage) return;
+    let isAlternate = false;
+    const tick = () => {
+      // TTS: only speak when idle, so the looping "Processing" never cuts off streamed
+      // speech. It repeats while a tool phase runs and pauses while text is spoken.
+      speechService.speakIfIdle("Processing");
+      // Screen reader: a polite (not assertive) region so it doesn't clobber streamed
+      // text; alternate a non-breaking space to force re-announcement of the same string.
+      isAlternate = !isAlternate;
+      setAnnounce(isAlternate ? "Processing " : "Processing");
+    };
+    tick();
+    const interval = setInterval(tick, 4000);
+    return () => clearInterval(interval);
+  }, [playProcessingMessage, speechService]);
 
   return (
     <div
@@ -40,6 +43,9 @@ export const LoadingMessage = observer(function LoadingMessage() {
         <div className="loading">
           Processing
         </div>
+      </div>
+      <div className="visually-hidden" role="status" aria-live="polite">
+        {announce}
       </div>
     </div>
   );

--- a/src/components/readaloud-menu.tsx
+++ b/src/components/readaloud-menu.tsx
@@ -23,7 +23,6 @@ export const ReadAloudMenu: React.FC<IProps> = observer(function ReadAloudMenu({
       <h3 id="readaloud-heading">Read Responses Aloud</h3>
       <div className="options-list-1">
         {createToggleOption("readAloudEnabled", "Read responses aloud", readAloudHelperTextId)}
-        {createToggleOption("streamResponses", "Stream responses", streamResponsesHelperTextId)}
         <div className="user-option">
           <label
             data-testid="speed-label"
@@ -54,6 +53,7 @@ export const ReadAloudMenu: React.FC<IProps> = observer(function ReadAloudMenu({
           Note: If you use a screen reader, you may hear duplicate audio when this feature is enabled.
           Press Escape to stop speech playback at any time.
         </p>
+        {createToggleOption("streamResponses", "Stream responses", streamResponsesHelperTextId)}
         <p className="helper-text" id={streamResponsesHelperTextId} data-testid="stream-responses-helper-text">
           Show and read responses sentence by sentence as they are generated. If your screen
           reader only announces the last line of a response (for example, VoiceOver), turn this

--- a/src/components/readaloud-menu.tsx
+++ b/src/components/readaloud-menu.tsx
@@ -10,6 +10,7 @@ interface IProps {
 export const ReadAloudMenu: React.FC<IProps> = observer(function ReadAloudMenu({createToggleOption}) {
   const appConfig = useAppConfigContext();
   const readAloudHelperTextId = "read-aloud-helper-text";
+  const streamResponsesHelperTextId = "stream-responses-helper-text";
 
   const handleSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
     appConfig.update(() => {
@@ -22,6 +23,7 @@ export const ReadAloudMenu: React.FC<IProps> = observer(function ReadAloudMenu({
       <h3 id="readaloud-heading">Read Responses Aloud</h3>
       <div className="options-list-1">
         {createToggleOption("readAloudEnabled", "Read responses aloud", readAloudHelperTextId)}
+        {createToggleOption("streamResponses", "Stream responses", streamResponsesHelperTextId)}
         <div className="user-option">
           <label
             data-testid="speed-label"
@@ -51,6 +53,11 @@ export const ReadAloudMenu: React.FC<IProps> = observer(function ReadAloudMenu({
         <p className="helper-text" id={readAloudHelperTextId} data-testid="readaloud-helper-text">
           Note: If you use a screen reader, you may hear duplicate audio when this feature is enabled.
           Press Escape to stop speech playback at any time.
+        </p>
+        <p className="helper-text" id={streamResponsesHelperTextId} data-testid="stream-responses-helper-text">
+          Show and read responses sentence by sentence as they are generated. If your screen
+          reader only announces the last line of a response (for example, VoiceOver), turn this
+          off to receive the full response at once.
         </p>
       </div>
     </div>

--- a/src/components/speaking-indicator.scss
+++ b/src/components/speaking-indicator.scss
@@ -1,6 +1,14 @@
 @use "./vars.scss" as *;
 
 .speaking-indicator {
+  // Float on top at the very top of the DAVAI window instead of taking layout
+  // space (which would push the rest of the content down while speaking).
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  white-space: nowrap;
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -10,6 +18,7 @@
   border-radius: 4px;
   font-size: 0.875rem;
   color: $dark-teal;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
 
   .speaking-icon {
     width: 12px;

--- a/src/components/speaking-indicator.test.tsx
+++ b/src/components/speaking-indicator.test.tsx
@@ -10,6 +10,7 @@ import { mockAppConfig } from "../test-utils/mock-app-config";
 const createMockSpeechService = (): ISpeechService => ({
   speak: jest.fn(),
   stopSpeech: jest.fn(),
+  enqueue: jest.fn(),
   isSpeaking: jest.fn(() => false),
   dispose: jest.fn(),
   onSpeakingChange: jest.fn(() => jest.fn()),

--- a/src/components/speaking-indicator.test.tsx
+++ b/src/components/speaking-indicator.test.tsx
@@ -10,6 +10,7 @@ import { mockAppConfig } from "../test-utils/mock-app-config";
 const createMockSpeechService = (): ISpeechService => ({
   speak: jest.fn(),
   stopSpeech: jest.fn(),
+  stopAndSuppress: jest.fn(),
   enqueue: jest.fn(),
   speakIfIdle: jest.fn(),
   resumeSpeech: jest.fn(),
@@ -82,7 +83,7 @@ describe("SpeakingIndicator", () => {
     expect(screen.getByRole("status")).toBeInTheDocument();
   });
 
-  it("stop button has accessible label and calls stopSpeech", () => {
+  it("stop button has accessible label and suppresses the rest of the response", () => {
     const { speechService } = renderSpeakingIndicator({
       readAloudEnabled: true, isSpeaking: true, currentSpeechText: "Hello"
     });
@@ -90,7 +91,9 @@ describe("SpeakingIndicator", () => {
     const stopButton = screen.getByTestId("stop-speech-button");
     expect(stopButton).toHaveAttribute("aria-label", "Stop speech");
 
+    // Must suppress (not just stopSpeech), so streamed chunks arriving afterward
+    // don't resume speech — parity with the Escape key.
     fireEvent.click(stopButton);
-    expect(speechService.stopSpeech).toHaveBeenCalled();
+    expect(speechService.stopAndSuppress).toHaveBeenCalled();
   });
 });

--- a/src/components/speaking-indicator.test.tsx
+++ b/src/components/speaking-indicator.test.tsx
@@ -12,6 +12,7 @@ const createMockSpeechService = (): ISpeechService => ({
   stopSpeech: jest.fn(),
   enqueue: jest.fn(),
   speakIfIdle: jest.fn(),
+  resumeSpeech: jest.fn(),
   isSpeaking: jest.fn(() => false),
   dispose: jest.fn(),
   onSpeakingChange: jest.fn(() => jest.fn()),
@@ -22,6 +23,7 @@ interface RenderOptions {
   isSpeaking?: boolean;
   currentSpeechText?: string | null;
   speechService?: ISpeechService;
+  isProcessing?: boolean;
 }
 
 const renderSpeakingIndicator = ({
@@ -29,6 +31,7 @@ const renderSpeakingIndicator = ({
   isSpeaking = false,
   currentSpeechText = null,
   speechService,
+  isProcessing = false,
 }: RenderOptions = {}) => {
   const appConfig = AppConfigModel.create({
     ...mockAppConfig,
@@ -39,7 +42,7 @@ const renderSpeakingIndicator = ({
   render(
     <AppConfigContext.Provider value={appConfig}>
       <SpeechServiceContext.Provider value={{ speechService: mockService, isSpeaking, currentSpeechText }}>
-        <SpeakingIndicator />
+        <SpeakingIndicator isProcessing={isProcessing} />
       </SpeechServiceContext.Provider>
     </AppConfigContext.Provider>
   );
@@ -66,6 +69,11 @@ describe("SpeakingIndicator", () => {
 
   it("does not render when current speech text is a processing message", () => {
     renderSpeakingIndicator({ readAloudEnabled: true, isSpeaking: true, currentSpeechText: "Processing your request" });
+    expect(screen.queryByTestId("speaking-indicator")).not.toBeInTheDocument();
+  });
+
+  it("does not render while processing (loading), even if speaking", () => {
+    renderSpeakingIndicator({ readAloudEnabled: true, isSpeaking: true, currentSpeechText: "Hello", isProcessing: true });
     expect(screen.queryByTestId("speaking-indicator")).not.toBeInTheDocument();
   });
 

--- a/src/components/speaking-indicator.test.tsx
+++ b/src/components/speaking-indicator.test.tsx
@@ -11,6 +11,7 @@ const createMockSpeechService = (): ISpeechService => ({
   speak: jest.fn(),
   stopSpeech: jest.fn(),
   enqueue: jest.fn(),
+  speakIfIdle: jest.fn(),
   isSpeaking: jest.fn(() => false),
   dispose: jest.fn(),
   onSpeakingChange: jest.fn(() => jest.fn()),

--- a/src/components/speaking-indicator.tsx
+++ b/src/components/speaking-indicator.tsx
@@ -24,7 +24,9 @@ export const SpeakingIndicator: React.FC<IProps> = ({ isProcessing }) => {
   }
 
   const handleStopClick = () => {
-    speechService.stopSpeech();
+    // Suppress (not just stop) so chunks streamed in afterward don't resume speech —
+    // parity with the Escape key. A new response lifts the suppression.
+    speechService.stopAndSuppress();
   };
 
   return (

--- a/src/components/speaking-indicator.tsx
+++ b/src/components/speaking-indicator.tsx
@@ -4,16 +4,22 @@ import { useAppConfigContext } from "../contexts/app-config-context";
 
 import "./speaking-indicator.scss";
 
-export const SpeakingIndicator: React.FC = () => {
+interface IProps {
+  // True while DAVAI is in a "Processing…" phase; the indicator hides then, since the
+  // spoken "Processing" announcement (via speakIfIdle) no longer sets currentSpeechText.
+  isProcessing?: boolean;
+}
+
+export const SpeakingIndicator: React.FC<IProps> = ({ isProcessing }) => {
   const appConfig = useAppConfigContext();
   const isSpeaking = useIsSpeaking();
   const speechService = useSpeechService();
   const currentSpeechText = useCurrentSpeechText();
 
-  // Don't show indicator for "Processing" messages - they're brief and transient
+  // Don't show the indicator for the transient "Processing" announcement.
   const isProcessingMessage = currentSpeechText?.trim().toLowerCase().startsWith("processing");
 
-  if (!appConfig.readAloudEnabled || !isSpeaking || isProcessingMessage) {
+  if (!appConfig.readAloudEnabled || !isSpeaking || isProcessing || isProcessingMessage) {
     return null;
   }
 

--- a/src/components/streaming-announcer.test.tsx
+++ b/src/components/streaming-announcer.test.tsx
@@ -58,6 +58,15 @@ it("after a finished stream, a new streamed turn is still announced", () => {
   void idB;
 });
 
+it("strips markdown from the spoken/announced text", () => {
+  const t = ChatTranscriptModel.create({ messages: [] });
+  const enqueue = jest.fn();
+  t.addStreamingMessage("DAVAI", { content: "This is **bold** text." });
+  render(provider(t, enqueue));
+  expect(enqueue).toHaveBeenCalledWith("This is bold text.");
+  expect(enqueue).not.toHaveBeenCalledWith(expect.stringContaining("*"));
+});
+
 it("removing the tracked message stops queued speech", () => {
   const t = ChatTranscriptModel.create({ messages: [] });
   const enqueue = jest.fn();

--- a/src/components/streaming-announcer.test.tsx
+++ b/src/components/streaming-announcer.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import { StreamingAnnouncer } from "./streaming-announcer";
 import { SpeechServiceContext } from "../contexts/speech-service-context";
 import { ChatTranscriptModel } from "../models/chat-transcript-model";
@@ -16,8 +16,10 @@ it("enqueues each completed sentence as the streaming message grows", () => {
   const id = t.addStreamingMessage("DAVAI", { content: "One." });
   const { rerender } = render(provider(t, enqueue));
   expect(enqueue).toHaveBeenCalledWith("One.");
-  t.appendToMessage(id, " Two.");
-  rerender(provider(t, enqueue));
+  act(() => {
+    t.appendToMessage(id, " Two.");
+    rerender(provider(t, enqueue));
+  });
   expect(enqueue).toHaveBeenCalledWith("Two.");
 });
 
@@ -27,7 +29,9 @@ it("flushes the final remainder when the message finalizes (even without trailin
   const id = t.addStreamingMessage("DAVAI", { content: "All done" });
   const { rerender } = render(provider(t, enqueue));
   expect(enqueue).not.toHaveBeenCalled(); // no completed sentence yet
-  t.finalizeStreamingMessage(id, "All done now");
-  rerender(provider(t, enqueue));
+  act(() => {
+    t.finalizeStreamingMessage(id, "All done now");
+    rerender(provider(t, enqueue));
+  });
   expect(enqueue).toHaveBeenCalledWith("All done now");
 });

--- a/src/components/streaming-announcer.test.tsx
+++ b/src/components/streaming-announcer.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { StreamingAnnouncer } from "./streaming-announcer";
+import { SpeechServiceContext } from "../contexts/speech-service-context";
+import { ChatTranscriptModel } from "../models/chat-transcript-model";
+
+const provider = (t: any, enqueue: jest.Mock) => (
+  <SpeechServiceContext.Provider value={{ speechService: { enqueue } as any, isSpeaking: false, currentSpeechText: null }}>
+    <StreamingAnnouncer transcript={t} />
+  </SpeechServiceContext.Provider>
+);
+
+it("enqueues each completed sentence as the streaming message grows", () => {
+  const t = ChatTranscriptModel.create({ messages: [] });
+  const enqueue = jest.fn();
+  const id = t.addStreamingMessage("DAVAI", { content: "One." });
+  const { rerender } = render(provider(t, enqueue));
+  expect(enqueue).toHaveBeenCalledWith("One.");
+  t.appendToMessage(id, " Two.");
+  rerender(provider(t, enqueue));
+  expect(enqueue).toHaveBeenCalledWith("Two.");
+});
+
+it("flushes the final remainder when the message finalizes (even without trailing punctuation)", () => {
+  const t = ChatTranscriptModel.create({ messages: [] });
+  const enqueue = jest.fn();
+  const id = t.addStreamingMessage("DAVAI", { content: "All done" });
+  const { rerender } = render(provider(t, enqueue));
+  expect(enqueue).not.toHaveBeenCalled(); // no completed sentence yet
+  t.finalizeStreamingMessage(id, "All done now");
+  rerender(provider(t, enqueue));
+  expect(enqueue).toHaveBeenCalledWith("All done now");
+});

--- a/src/components/streaming-announcer.test.tsx
+++ b/src/components/streaming-announcer.test.tsx
@@ -5,7 +5,7 @@ import { SpeechServiceContext } from "../contexts/speech-service-context";
 import { ChatTranscriptModel } from "../models/chat-transcript-model";
 
 const provider = (t: any, enqueue: jest.Mock, stopSpeech?: jest.Mock) => (
-  <SpeechServiceContext.Provider value={{ speechService: { enqueue, stopSpeech: stopSpeech ?? jest.fn() } as any, isSpeaking: false, currentSpeechText: null }}>
+  <SpeechServiceContext.Provider value={{ speechService: { enqueue, stopSpeech: stopSpeech ?? jest.fn(), resumeSpeech: jest.fn() } as any, isSpeaking: false, currentSpeechText: null }}>
     <StreamingAnnouncer transcript={t} />
   </SpeechServiceContext.Provider>
 );

--- a/src/components/streaming-announcer.test.tsx
+++ b/src/components/streaming-announcer.test.tsx
@@ -18,8 +18,8 @@ it("enqueues each completed sentence as the streaming message grows", () => {
   expect(enqueue).toHaveBeenCalledWith("One.");
   act(() => {
     t.appendToMessage(id, " Two.");
-    rerender(provider(t, enqueue));
   });
+  rerender(provider(t, enqueue));
   expect(enqueue).toHaveBeenCalledWith("Two.");
 });
 
@@ -31,7 +31,7 @@ it("flushes the final remainder when the message finalizes (even without trailin
   expect(enqueue).not.toHaveBeenCalled(); // no completed sentence yet
   act(() => {
     t.finalizeStreamingMessage(id, "All done now");
-    rerender(provider(t, enqueue));
   });
+  rerender(provider(t, enqueue));
   expect(enqueue).toHaveBeenCalledWith("All done now");
 });

--- a/src/components/streaming-announcer.test.tsx
+++ b/src/components/streaming-announcer.test.tsx
@@ -4,8 +4,8 @@ import { StreamingAnnouncer } from "./streaming-announcer";
 import { SpeechServiceContext } from "../contexts/speech-service-context";
 import { ChatTranscriptModel } from "../models/chat-transcript-model";
 
-const provider = (t: any, enqueue: jest.Mock) => (
-  <SpeechServiceContext.Provider value={{ speechService: { enqueue } as any, isSpeaking: false, currentSpeechText: null }}>
+const provider = (t: any, enqueue: jest.Mock, stopSpeech?: jest.Mock) => (
+  <SpeechServiceContext.Provider value={{ speechService: { enqueue, stopSpeech: stopSpeech ?? jest.fn() } as any, isSpeaking: false, currentSpeechText: null }}>
     <StreamingAnnouncer transcript={t} />
   </SpeechServiceContext.Provider>
 );
@@ -34,4 +34,40 @@ it("flushes the final remainder when the message finalizes (even without trailin
   });
   rerender(provider(t, enqueue));
   expect(enqueue).toHaveBeenCalledWith("All done now");
+});
+
+it("after a finished stream, a new streamed turn is still announced", () => {
+  const t = ChatTranscriptModel.create({ messages: [] });
+  const enqueue = jest.fn();
+
+  // Turn A
+  const idA = t.addStreamingMessage("DAVAI", { content: "One." });
+  const { rerender } = render(provider(t, enqueue));
+  expect(enqueue).toHaveBeenCalledWith("One.");
+
+  // Simulate finishStream: finalizeStreamingMessage keeps content, clears isStreaming
+  act(() => { t.finalizeStreamingMessage(idA, "One."); });
+  rerender(provider(t, enqueue));
+
+  // Turn B — should still be announced
+  let idB!: string;
+  act(() => { idB = t.addStreamingMessage("DAVAI", { content: "Two." }); });
+  rerender(provider(t, enqueue));
+  expect(enqueue).toHaveBeenCalledWith("Two.");
+  // Silence TS unused-variable warning
+  void idB;
+});
+
+it("removing the tracked message stops queued speech", () => {
+  const t = ChatTranscriptModel.create({ messages: [] });
+  const enqueue = jest.fn();
+  const stopSpeech = jest.fn();
+
+  const idA = t.addStreamingMessage("DAVAI", { content: "Hello." });
+  const { rerender } = render(provider(t, enqueue, stopSpeech));
+  expect(enqueue).toHaveBeenCalledWith("Hello.");
+
+  act(() => { t.removeMessage(idA); });
+  rerender(provider(t, enqueue, stopSpeech));
+  expect(stopSpeech).toHaveBeenCalled();
 });

--- a/src/components/streaming-announcer.test.tsx
+++ b/src/components/streaming-announcer.test.tsx
@@ -67,12 +67,12 @@ it("strips markdown from the spoken/announced text", () => {
   expect(enqueue).not.toHaveBeenCalledWith(expect.stringContaining("*"));
 });
 
-it("voices a bullet marker as • instead of reading the raw symbol", () => {
+it("voices a bullet marker as the word 'bullet' instead of reading the raw symbol", () => {
   const t = ChatTranscriptModel.create({ messages: [] });
   const enqueue = jest.fn();
   t.addStreamingMessage("DAVAI", { content: "* First item\n" });
   render(provider(t, enqueue));
-  expect(enqueue).toHaveBeenCalledWith("• First item");
+  expect(enqueue).toHaveBeenCalledWith("bullet First item");
   expect(enqueue).not.toHaveBeenCalledWith(expect.stringContaining("*"));
 });
 

--- a/src/components/streaming-announcer.test.tsx
+++ b/src/components/streaming-announcer.test.tsx
@@ -67,6 +67,23 @@ it("strips markdown from the spoken/announced text", () => {
   expect(enqueue).not.toHaveBeenCalledWith(expect.stringContaining("*"));
 });
 
+it("voices a bullet marker as • instead of reading the raw symbol", () => {
+  const t = ChatTranscriptModel.create({ messages: [] });
+  const enqueue = jest.fn();
+  t.addStreamingMessage("DAVAI", { content: "* First item\n" });
+  render(provider(t, enqueue));
+  expect(enqueue).toHaveBeenCalledWith("• First item");
+  expect(enqueue).not.toHaveBeenCalledWith(expect.stringContaining("*"));
+});
+
+it("preserves a numbered list marker", () => {
+  const t = ChatTranscriptModel.create({ messages: [] });
+  const enqueue = jest.fn();
+  t.addStreamingMessage("DAVAI", { content: "1. Numbered item\n" });
+  render(provider(t, enqueue));
+  expect(enqueue).toHaveBeenCalledWith("1. Numbered item");
+});
+
 it("removing the tracked message stops queued speech", () => {
   const t = ChatTranscriptModel.create({ messages: [] });
   const enqueue = jest.fn();

--- a/src/components/streaming-announcer.tsx
+++ b/src/components/streaming-announcer.tsx
@@ -29,10 +29,12 @@ export const StreamingAnnouncer = observer(({ transcript }: IProps) => {
   const trackedContent = tracked?.messageContent.content ?? "";
   const trackedDone = tracked ? !tracked.isStreaming : false;
 
-  // New streaming message → clear the previous nodes.
+  // New streaming message → clear the previous nodes and clear any Escape suppression
+  // from a prior response (so the new response is read).
   useEffect(() => {
     setNodes([]);
-  }, [streaming?.id]);
+    if (streaming?.id) speechService.resumeSpeech();
+  }, [streaming?.id, speechService]);
 
   // If the tracked streaming message was removed (discarded on a mixed text+tool
   // turn), stop any queued speech for it and reset.

--- a/src/components/streaming-announcer.tsx
+++ b/src/components/streaming-announcer.tsx
@@ -1,26 +1,11 @@
 import React, { useEffect, useRef, useState } from "react";
 import { observer } from "mobx-react-lite";
-import removeMarkdown from "remove-markdown";
 import { ChatTranscript } from "../types";
 import { useSpeechService } from "../contexts/speech-service-context";
 import { extractCompletedChunks } from "../utils/stream-utils";
+import { chunkToSpeech, TableSpeechState } from "../utils/speech-text";
 
 interface IProps { transcript: ChatTranscript; }
-
-// Strip markdown so the screen reader and TTS don't read formatting symbols aloud
-// (e.g. "asterisk asterisk bold asterisk asterisk"), but KEEP an indication of list
-// structure: a bullet marker (-, *, +) becomes "•" (voiced "bullet") and a numbered
-// marker (e.g. "1.") is preserved, with the rest of the item's markdown stripped.
-const BULLET_RE = /^(\s*)[-*+]\s+(.*)$/;
-const NUMBER_RE = /^(\s*)(\d+)[.)]\s+(.*)$/;
-const forSpeech = (text: string): string => {
-  const strip = (s: string) => removeMarkdown(s, { useImgAltText: true });
-  const bullet = text.match(BULLET_RE);
-  if (bullet) return `• ${strip(bullet[2])}`;
-  const numbered = text.match(NUMBER_RE);
-  if (numbered) return `${numbered[2]}. ${strip(numbered[3])}`;
-  return removeMarkdown(text, { stripListLeaders: false, useImgAltText: true });
-};
 
 // Observes the single streaming DAVAI message and drives streamed a11y output:
 // each newly-completed sentence/bullet is spoken (queued, never interrupting) and
@@ -30,6 +15,7 @@ export const StreamingAnnouncer = observer(({ transcript }: IProps) => {
   const [nodes, setNodes] = useState<{ key: string; text: string }[]>([]);
   const consumedRef = useRef(0);
   const idRef = useRef<string | undefined>(undefined);
+  const tableStateRef = useRef<TableSpeechState>({ header: null });
 
   // Track the streaming message BY ID so we still see it after it finalizes
   // (isStreaming flips to false) and can flush its final sentence.
@@ -37,6 +23,7 @@ export const StreamingAnnouncer = observer(({ transcript }: IProps) => {
   if (streaming && streaming.id !== idRef.current) {
     idRef.current = streaming.id;       // adjust refs during render (allowed for prop-derived state)
     consumedRef.current = 0;
+    tableStateRef.current = { header: null };
   }
   const tracked = idRef.current ? transcript.messages.find((m) => m.id === idRef.current) : undefined;
   const trackedContent = tracked?.messageContent.content ?? "";
@@ -67,8 +54,9 @@ export const StreamingAnnouncer = observer(({ transcript }: IProps) => {
       // Advance consumption by the RAW extraction (independent of markdown stripping),
       // so a markdown-only chunk can't stall progress.
       consumedRef.current = trackedDone ? trackedContent.length : trackedContent.length - remainder.length;
-      // Strip markdown for the spoken/announced text; drop chunks that are empty once stripped.
-      const spoken = rawToEmit.map(forSpeech).filter((t) => t.trim());
+      // Strip markdown + linearize table rows for the spoken/announced text; drop
+      // chunks that are empty once processed (e.g. table header/separator rows).
+      const spoken = rawToEmit.map((c) => chunkToSpeech(c, tableStateRef.current)).filter((t) => t.trim());
       if (spoken.length > 0) {
         for (const text of spoken) speechService.enqueue(text);
         const base = consumedRef.current;

--- a/src/components/streaming-announcer.tsx
+++ b/src/components/streaming-announcer.tsx
@@ -31,6 +31,16 @@ export const StreamingAnnouncer = observer(({ transcript }: IProps) => {
     setNodes([]);
   }, [streaming?.id]);
 
+  // If the tracked streaming message was removed (discarded on a mixed text+tool
+  // turn), stop any queued speech for it and reset.
+  useEffect(() => {
+    if (idRef.current && !tracked) {
+      speechService.stopSpeech();
+      idRef.current = undefined;
+      setNodes([]);
+    }
+  }, [tracked, speechService]);
+
   // Emit newly-completed chunks; on finalize, force-flush the remaining tail.
   useEffect(() => {
     if (!idRef.current || !tracked) return;

--- a/src/components/streaming-announcer.tsx
+++ b/src/components/streaming-announcer.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useRef, useState } from "react";
+import { observer } from "mobx-react-lite";
+import { ChatTranscript } from "../types";
+import { useSpeechService } from "../contexts/speech-service-context";
+import { extractCompletedChunks } from "../utils/stream-utils";
+
+interface IProps { transcript: ChatTranscript; }
+
+// Observes the single streaming DAVAI message and drives streamed a11y output:
+// each newly-completed sentence/bullet is spoken (queued, never interrupting) and
+// appended as a separate node in a polite live region (screen readers queue these).
+export const StreamingAnnouncer = observer(({ transcript }: IProps) => {
+  const speechService = useSpeechService();
+  const [nodes, setNodes] = useState<{ key: string; text: string }[]>([]);
+  const consumedRef = useRef(0);
+  const idRef = useRef<string | undefined>(undefined);
+
+  // Track the streaming message BY ID so we still see it after it finalizes
+  // (isStreaming flips to false) and can flush its final sentence.
+  const streaming = transcript.messages.find((m) => m.isStreaming);
+  if (streaming && streaming.id !== idRef.current) {
+    idRef.current = streaming.id;       // adjust refs during render (allowed for prop-derived state)
+    consumedRef.current = 0;
+  }
+  const tracked = idRef.current ? transcript.messages.find((m) => m.id === idRef.current) : undefined;
+  const trackedContent = tracked?.messageContent.content ?? "";
+  const trackedDone = tracked ? !tracked.isStreaming : false;
+
+  // New streaming message → clear the previous nodes.
+  useEffect(() => {
+    setNodes([]);
+  }, [streaming?.id]);
+
+  // Emit newly-completed chunks; on finalize, force-flush the remaining tail.
+  useEffect(() => {
+    if (!idRef.current || !tracked) return;
+    const pending = trackedContent.slice(consumedRef.current);
+    const { chunks, remainder } = extractCompletedChunks(pending);
+    const tail = trackedDone && remainder.trim() ? [remainder.trim()] : [];
+    const toEmit = [...chunks, ...tail];
+    if (toEmit.length > 0) {
+      consumedRef.current = trackedDone ? trackedContent.length : trackedContent.length - remainder.length;
+      for (const text of toEmit) speechService.enqueue(text);
+      const base = consumedRef.current;
+      setNodes((prev) => [
+        ...prev.slice(-9), // prune to keep the DOM small
+        ...toEmit.map((text, i) => ({ key: `${idRef.current}-${base}-${i}`, text })),
+      ]);
+    }
+    if (trackedDone) idRef.current = undefined; // stop tracking once finalized + flushed
+  }, [tracked, trackedContent, trackedDone, speechService]);
+
+  return (
+    <div className="visually-hidden" aria-live="polite" aria-atomic="false">
+      {nodes.map((n) => <div key={n.key}>{n.text}</div>)}
+    </div>
+  );
+});

--- a/src/components/streaming-announcer.tsx
+++ b/src/components/streaming-announcer.tsx
@@ -8,10 +8,19 @@ import { extractCompletedChunks } from "../utils/stream-utils";
 interface IProps { transcript: ChatTranscript; }
 
 // Strip markdown so the screen reader and TTS don't read formatting symbols aloud
-// (e.g. "asterisk asterisk bold asterisk asterisk"). Matches the options used by
-// the transcript's plainTextContent so spoken text matches the captured chat.
-const forSpeech = (text: string): string =>
-  removeMarkdown(text, { stripListLeaders: false, useImgAltText: true });
+// (e.g. "asterisk asterisk bold asterisk asterisk"), but KEEP an indication of list
+// structure: a bullet marker (-, *, +) becomes "•" (voiced "bullet") and a numbered
+// marker (e.g. "1.") is preserved, with the rest of the item's markdown stripped.
+const BULLET_RE = /^(\s*)[-*+]\s+(.*)$/;
+const NUMBER_RE = /^(\s*)(\d+)[.)]\s+(.*)$/;
+const forSpeech = (text: string): string => {
+  const strip = (s: string) => removeMarkdown(s, { useImgAltText: true });
+  const bullet = text.match(BULLET_RE);
+  if (bullet) return `• ${strip(bullet[2])}`;
+  const numbered = text.match(NUMBER_RE);
+  if (numbered) return `${numbered[2]}. ${strip(numbered[3])}`;
+  return removeMarkdown(text, { stripListLeaders: false, useImgAltText: true });
+};
 
 // Observes the single streaming DAVAI message and drives streamed a11y output:
 // each newly-completed sentence/bullet is spoken (queued, never interrupting) and

--- a/src/components/streaming-announcer.tsx
+++ b/src/components/streaming-announcer.tsx
@@ -1,10 +1,17 @@
 import React, { useEffect, useRef, useState } from "react";
 import { observer } from "mobx-react-lite";
+import removeMarkdown from "remove-markdown";
 import { ChatTranscript } from "../types";
 import { useSpeechService } from "../contexts/speech-service-context";
 import { extractCompletedChunks } from "../utils/stream-utils";
 
 interface IProps { transcript: ChatTranscript; }
+
+// Strip markdown so the screen reader and TTS don't read formatting symbols aloud
+// (e.g. "asterisk asterisk bold asterisk asterisk"). Matches the options used by
+// the transcript's plainTextContent so spoken text matches the captured chat.
+const forSpeech = (text: string): string =>
+  removeMarkdown(text, { stripListLeaders: false, useImgAltText: true });
 
 // Observes the single streaming DAVAI message and drives streamed a11y output:
 // each newly-completed sentence/bullet is spoken (queued, never interrupting) and
@@ -46,22 +53,29 @@ export const StreamingAnnouncer = observer(({ transcript }: IProps) => {
     if (!idRef.current || !tracked) return;
     const pending = trackedContent.slice(consumedRef.current);
     const { chunks, remainder } = extractCompletedChunks(pending);
-    const tail = trackedDone && remainder.trim() ? [remainder.trim()] : [];
-    const toEmit = [...chunks, ...tail];
-    if (toEmit.length > 0) {
+    const rawToEmit = [...chunks, ...(trackedDone && remainder.trim() ? [remainder.trim()] : [])];
+    if (rawToEmit.length > 0) {
+      // Advance consumption by the RAW extraction (independent of markdown stripping),
+      // so a markdown-only chunk can't stall progress.
       consumedRef.current = trackedDone ? trackedContent.length : trackedContent.length - remainder.length;
-      for (const text of toEmit) speechService.enqueue(text);
-      const base = consumedRef.current;
-      setNodes((prev) => [
-        ...prev.slice(-9), // prune to keep the DOM small
-        ...toEmit.map((text, i) => ({ key: `${idRef.current}-${base}-${i}`, text })),
-      ]);
+      // Strip markdown for the spoken/announced text; drop chunks that are empty once stripped.
+      const spoken = rawToEmit.map(forSpeech).filter((t) => t.trim());
+      if (spoken.length > 0) {
+        for (const text of spoken) speechService.enqueue(text);
+        const base = consumedRef.current;
+        setNodes((prev) => [
+          ...prev.slice(-9), // prune to keep the DOM small
+          ...spoken.map((text, i) => ({ key: `${idRef.current}-${base}-${i}`, text })),
+        ]);
+      }
     }
     if (trackedDone) idRef.current = undefined; // stop tracking once finalized + flushed
   }, [tracked, trackedContent, trackedDone, speechService]);
 
+  // role="log" makes additions announced in order (better cross-AT, esp. VoiceOver,
+  // which clobbers plain aria-live="polite" regions on rapid updates).
   return (
-    <div className="visually-hidden" aria-live="polite" aria-atomic="false">
+    <div className="visually-hidden" role="log" aria-live="polite" aria-atomic="false">
       {nodes.map((n) => <div key={n.key}>{n.text}</div>)}
     </div>
   );

--- a/src/components/user-options.scss
+++ b/src/components/user-options.scss
@@ -11,6 +11,11 @@
 
     p { font-size: .75rem; }
 
+    .helper-text {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
     // Top level list of options usually just below a heading
     .options-list-1 {
       padding: 5px 0px;

--- a/src/components/user-options.tsx
+++ b/src/components/user-options.tsx
@@ -41,17 +41,6 @@ export const UserOptions: React.FC<IProps> = observer(function UserOptions({assi
     <div className="user-options control-panel" role="group" aria-labelledby="control-panel-heading">
       <h2 id="control-panel-heading">Options</h2>
       <ReadAloudMenu createToggleOption={createToggleOption}/>
-      <div className="control-panel-section" role="group" aria-labelledby="responses-heading">
-        <h3 id="responses-heading">Responses</h3>
-        <div className="options-list-1">
-          {createToggleOption("streamResponses", "Stream responses", "stream-responses-helper-text")}
-        </div>
-        <p className="helper-text" id="stream-responses-helper-text" data-testid="stream-responses-helper-text">
-          Show and read responses sentence by sentence as they are generated. If your screen
-          reader only announces the last line of a response (for example, VoiceOver), turn this
-          off to receive the full response at once.
-        </p>
-      </div>
       <div className="control-panel-section" role="group" aria-labelledby="loading-indicators-heading">
         <h3 id="loading-indicators-heading">Loading Indicators</h3>
         <div className="options-list-1">

--- a/src/components/user-options.tsx
+++ b/src/components/user-options.tsx
@@ -41,6 +41,17 @@ export const UserOptions: React.FC<IProps> = observer(function UserOptions({assi
     <div className="user-options control-panel" role="group" aria-labelledby="control-panel-heading">
       <h2 id="control-panel-heading">Options</h2>
       <ReadAloudMenu createToggleOption={createToggleOption}/>
+      <div className="control-panel-section" role="group" aria-labelledby="responses-heading">
+        <h3 id="responses-heading">Responses</h3>
+        <div className="options-list-1">
+          {createToggleOption("streamResponses", "Stream responses", "stream-responses-helper-text")}
+        </div>
+        <p className="helper-text" id="stream-responses-helper-text" data-testid="stream-responses-helper-text">
+          Show and read responses sentence by sentence as they are generated. If your screen
+          reader only announces the last line of a response (for example, VoiceOver), turn this
+          off to receive the full response at once.
+        </p>
+      </div>
       <div className="control-panel-section" role="group" aria-labelledby="loading-indicators-heading">
         <h3 id="loading-indicators-heading">Loading Indicators</h3>
         <div className="options-list-1">

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const USER_SPEAKER = "User";
 // see: https://platform.openai.com/docs/api-reference/runs/object#runs/object-status
 export const WAIT_STATES = new Set(["queued", "in_progress"]);
 export const ERROR_STATES = new Set(["failed", "incomplete", "expired", "cancelled"]);
+export const STREAMING_STATUS = "streaming";
 
 export const GREETING = `Hello! I'm DAVAI, your Data Analysis through Voice and Artificial Intelligence partner.`;
 

--- a/src/contexts/speech-service-context.test.tsx
+++ b/src/contexts/speech-service-context.test.tsx
@@ -74,6 +74,44 @@ describe("SpeechServiceContext", () => {
       const utterance = mockSynth.speak.mock.calls[0][0];
       expect(utterance.text).toBe("Test message");
     });
+
+    it("queues sequential announcements on one queue instead of interrupting", () => {
+      jest.useFakeTimers();
+      const appConfig = AppConfigModel.create({
+        ...mockAppConfig,
+        readAloudEnabled: true,
+      } as AppConfigModelSnapshot);
+      let setText: (t: string) => void = () => { /* set on render */ };
+      const TestComponent = () => {
+        const { setAriaLiveText } = useAriaLive();
+        setText = setAriaLiveText;
+        return null;
+      };
+      render(
+        <AppConfigContext.Provider value={appConfig}>
+          <AriaLiveProvider>
+            <SpeechServiceProvider>
+              <TestComponent />
+            </SpeechServiceProvider>
+          </AriaLiveProvider>
+        </AppConfigContext.Provider>
+      );
+
+      act(() => { setText("First."); });
+      act(() => { jest.advanceTimersByTime(100); });
+      act(() => { setText("Second."); });
+      act(() => { jest.advanceTimersByTime(100); });
+
+      // The second announcement must NOT cancel the first — it queues behind it.
+      expect(mockSynth.cancel).not.toHaveBeenCalled();
+      expect(mockSynth.speak).toHaveBeenCalledTimes(1);
+      expect(mockSynth.speak.mock.calls[0][0].text).toBe("First.");
+
+      // When the first finishes, the second plays.
+      act(() => { mockSynth.speak.mock.calls[0][0].onend?.({} as Event); });
+      expect(mockSynth.speak).toHaveBeenCalledTimes(2);
+      expect(mockSynth.speak.mock.calls[1][0].text).toBe("Second.");
+    });
   });
 
   describe("useSpeechService", () => {

--- a/src/contexts/speech-service-context.tsx
+++ b/src/contexts/speech-service-context.tsx
@@ -51,10 +51,15 @@ export const SpeechServiceProvider = ({ children }: { children: React.ReactNode 
         clearTimeout(debounceTimeoutRef.current);
       }
 
-      // Debounce speech to avoid rapid cancellations
+      // Debounce, then queue onto the shared TTS queue (instead of interrupting), so
+      // sequential announcements within a turn — e.g. text the model emits before a tool
+      // call, then the final answer — are read in order rather than clobbering each other.
+      // resumeSpeech clears any prior Escape suppression for this new response. Explicit
+      // interrupts (Escape, the Stop button, replay) still call stopSpeech/stopAndSuppress.
       debounceTimeoutRef.current = setTimeout(() => {
         setCurrentSpeechText(ariaLiveText);
-        speechService.speak(ariaLiveText);
+        speechService.resumeSpeech();
+        speechService.enqueue(ariaLiveText);
         debounceTimeoutRef.current = null;
       }, 100);
     }

--- a/src/models/app-config-model.test.ts
+++ b/src/models/app-config-model.test.ts
@@ -1,9 +1,17 @@
 import { AppConfigModel, AppConfigModelSnapshot } from "./app-config-model";
 import appConfigJson from "../app-config.json";
+import { mockAppConfig } from "../test-utils/mock-app-config";
 
 describe("AppConfigModel keyboard shortcuts", () => {
   it("includes the captureTranscript shortcut from app-config.json", () => {
     const appConfig = AppConfigModel.create(appConfigJson as AppConfigModelSnapshot);
     expect(appConfig.keyboardShortcuts.captureTranscript).toBe("Control+Shift+Semicolon");
+  });
+});
+
+describe("AppConfigModel streamResponses", () => {
+  it("defaults streamResponses to true", () => {
+    const config = AppConfigModel.create(mockAppConfig);
+    expect(config.streamResponses).toBe(true);
   });
 });

--- a/src/models/app-config-model.ts
+++ b/src/models/app-config-model.ts
@@ -145,6 +145,7 @@ export const AppConfigModel = types.model("AppConfigModel", {
   playProcessingTone: types.boolean,
   playbackSpeed: types.number,
   readAloudEnabled: types.boolean,
+  streamResponses: types.boolean,
   /**
    * The unique ID of an LLM to use, or "mock" for a mocked LLM.
    * Note: for a real LLM it is a stringified JSON object, not just the ID from the llmList object.

--- a/src/models/assistant-model.test.ts
+++ b/src/models/assistant-model.test.ts
@@ -91,4 +91,46 @@ describe("AssistantModel streaming busy-state (DAVAI-118)", () => {
     expect(begin).toHaveLength(1);
     expect(completed).toHaveLength(1);
   });
+
+  it("finalizes the in-progress streaming message if the turn throws after streaming started", async () => {
+    const store = createStore();
+    store.setStreamEnabled(true);
+    mockedPostMessage
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ messageId: "m1" }) } as Response) // submit
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: "streaming", output: { response: "Partial..." } }) } as Response) // streamed chunk
+      .mockResolvedValueOnce({ ok: false, statusText: "Boom" } as Response); // next status fetch throws
+
+    await store.handleMessageSubmit("hello");
+
+    // The streaming message must be finalized (not left stuck isStreaming) and keep its text.
+    expect(store.transcriptStore.messages.some((m) => m.isStreaming)).toBe(false);
+    expect(store.transcriptStore.messages.some((m) => m.messageContent.content === "Partial...")).toBe(true);
+    expect(store.currentStreamingMessageId).toBeNull();
+  });
+
+  it("does not time out while the server reports streaming progress, even with streaming display off", async () => {
+    const store = createStore();
+    store.setStreamEnabled(false); // streaming display OFF — server still reports streaming status
+
+    // Advance the clock 30s on each status poll, so the 60s idle budget would expire after
+    // a couple of no-progress polls unless streaming statuses are counted as progress.
+    let now = 0;
+    const nowSpy = jest.spyOn(performance, "now").mockImplementation(() => now);
+    const streaming = (resp: string) =>
+      ({ ok: true, json: async () => { now += 30_000; return { status: "streaming", output: { response: resp } }; } } as unknown as Response);
+
+    mockedPostMessage
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ messageId: "m1" }) } as Response) // submit
+      .mockResolvedValueOnce(streaming("a"))
+      .mockResolvedValueOnce(streaming("ab"))
+      .mockResolvedValueOnce(streaming("abc"))
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: "completed", output: { response: "done" } }) } as Response);
+
+    await store.handleMessageSubmit("hello");
+
+    expect(store.transcriptStore.messages.some((m) => m.messageContent.content === "done")).toBe(true);
+    expect(store.transcriptStore.messages.some((m) => m.messageContent.description === "Polling expired before response received")).toBe(false);
+
+    nowSpy.mockRestore();
+  });
 });

--- a/src/models/assistant-model.test.ts
+++ b/src/models/assistant-model.test.ts
@@ -1,6 +1,7 @@
 import { AssistantModel } from "./assistant-model";
 import { ChatTranscriptModel } from "./chat-transcript-model";
 import { postMessage } from "../utils/llm-utils";
+import { DAVAI_SPEAKER } from "../constants";
 
 jest.mock("../utils/llm-utils", () => ({
   postMessage: jest.fn(),
@@ -90,6 +91,23 @@ describe("AssistantModel streaming busy-state (DAVAI-118)", () => {
     const completed = messages.filter((m) => m.messageContent.description === "Completed response time");
     expect(begin).toHaveLength(1);
     expect(completed).toHaveLength(1);
+  });
+
+  it("keeps the DAVAI response as the last transcript row for a non-streamed completion", async () => {
+    // App's announce/speak effect for non-streamed responses keys off "last message is a
+    // DAVAI message", so the timing debug rows must not be appended after the response.
+    const store = createStore();
+    store.setStreamEnabled(false);
+    mockedPostMessage
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ messageId: "m1" }) } as Response) // submit
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: "completed", output: { response: "Hi there." } }) } as Response); // status poll
+
+    await store.handleMessageSubmit("hello");
+
+    const messages = store.transcriptStore.messages;
+    const last = messages[messages.length - 1];
+    expect(last.speaker).toBe(DAVAI_SPEAKER);
+    expect(last.messageContent.content).toBe("Hi there.");
   });
 
   it("finalizes the in-progress streaming message if the turn throws after streaming started", async () => {

--- a/src/models/assistant-model.test.ts
+++ b/src/models/assistant-model.test.ts
@@ -76,4 +76,19 @@ describe("AssistantModel streaming busy-state (DAVAI-118)", () => {
     const legacy = messages.filter((m) => (m.messageContent.description ?? "").startsWith("Response time"));
     expect(legacy).toHaveLength(0);
   });
+
+  it("emits a 'Begin response time' for a non-streamed completion (paired with Completed)", async () => {
+    const store = createStore();
+    mockedPostMessage
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ messageId: "m1" }) } as Response) // submit
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: "completed", output: { response: "Hi there." } }) } as Response); // status poll
+
+    await store.handleMessageSubmit("hello");
+
+    const messages = store.transcriptStore.messages;
+    const begin = messages.filter((m) => m.messageContent.description === "Begin response time");
+    const completed = messages.filter((m) => m.messageContent.description === "Completed response time");
+    expect(begin).toHaveLength(1);
+    expect(completed).toHaveLength(1);
+  });
 });

--- a/src/models/assistant-model.test.ts
+++ b/src/models/assistant-model.test.ts
@@ -151,4 +151,25 @@ describe("AssistantModel streaming busy-state (DAVAI-118)", () => {
 
     nowSpy.mockRestore();
   });
+
+  it("keeps pre-tool-call text on a mixed text+tool turn with streaming display off", async () => {
+    const store = createStore();
+    store.setStreamEnabled(false);
+    store.setLlmId(JSON.stringify({ id: "gpt-4o-mini", provider: "OpenAI" })); // non-mock, so tool output is sent
+    mockedPostMessage
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ messageId: "m1" }) } as Response) // message submit
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: "completed", output: {
+        status: "requires_action", tool_call_id: "t1", type: "x",
+        request: { status: "error", error: "nope" }, // error request → forwarded without a CODAP round-trip
+        response: "Here is the explanation." // pre-tool text the server attached
+      } }) } as Response) // status: tool call carrying pre-tool text
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ messageId: "m2" }) } as Response) // tool-output submit
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: "completed", output: { response: "Final answer." } }) } as Response); // tool status
+
+    await store.handleMessageSubmit("hello");
+
+    const contents = store.transcriptStore.messages.map((m) => m.messageContent.content);
+    expect(contents).toContain("Here is the explanation."); // pre-tool text not dropped
+    expect(contents).toContain("Final answer.");
+  });
 });

--- a/src/models/assistant-model.test.ts
+++ b/src/models/assistant-model.test.ts
@@ -1,0 +1,63 @@
+import { AssistantModel } from "./assistant-model";
+import { ChatTranscriptModel } from "./chat-transcript-model";
+import { postMessage } from "../utils/llm-utils";
+
+jest.mock("../utils/llm-utils", () => ({
+  postMessage: jest.fn(),
+}));
+
+const mockedPostMessage = postMessage as jest.MockedFunction<typeof postMessage>;
+
+const createStore = () => {
+  const transcriptStore = ChatTranscriptModel.create({ messages: [] });
+  return AssistantModel.create({ transcriptStore, threadId: "thread-1" });
+};
+
+describe("AssistantModel streaming busy-state (DAVAI-118)", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("queues a second message instead of starting a concurrent request while one is in flight", async () => {
+    const store = createStore();
+    // Every postMessage call parks on a never-resolving promise, so the first submit
+    // stays "in flight" right after it sets isLoadingResponse = true. (We never await
+    // the submits — the queued path returns immediately; a buggy concurrent path would
+    // park on its own postMessage call, which the call-count assertion catches.)
+    mockedPostMessage.mockReturnValue(new Promise<Response>(() => { /* never resolves */ }));
+
+    store.handleMessageSubmit("first");
+    await Promise.resolve();
+    expect(store.isLoadingResponse).toBe(true);
+    expect(mockedPostMessage).toHaveBeenCalledTimes(1);
+
+    // A second submit while busy must NOT start another job (which would overwrite
+    // currentMessageId and corrupt polling/cancel); it should be queued for later.
+    store.handleMessageSubmit("second");
+    await Promise.resolve();
+
+    expect(mockedPostMessage).toHaveBeenCalledTimes(1);
+    expect(store.messageQueue.slice()).toContain("second");
+  });
+
+  it("still reports isResponding while streaming after the Processing indicator is cleared", async () => {
+    const store = createStore();
+    mockedPostMessage.mockReturnValue(new Promise<Response>(() => { /* never resolves */ }));
+
+    store.handleMessageSubmit("hello");
+    await Promise.resolve();
+    expect(store.isLoadingResponse).toBe(true);
+
+    // Streaming clears the "Processing" indicator on the first chunk, but the input must
+    // stay busy (cancel button up, submit blocked) — that's what isResponding expresses.
+    store.setShowLoadingIndicator(false);
+    expect(store.isResponding).toBe(true);
+  });
+
+  it("reports isResponding via showLoadingIndicator for the mock assistant (no isLoadingResponse)", () => {
+    const store = createStore();
+    expect(store.isResponding).toBe(false);
+    store.setShowLoadingIndicator(true);
+    expect(store.isResponding).toBe(true);
+  });
+});

--- a/src/models/assistant-model.test.ts
+++ b/src/models/assistant-model.test.ts
@@ -60,4 +60,20 @@ describe("AssistantModel streaming busy-state (DAVAI-118)", () => {
     store.setShowLoadingIndicator(true);
     expect(store.isResponding).toBe(true);
   });
+
+  it("logs a single 'Completed response time' and no legacy 'Response time' on completion", async () => {
+    const store = createStore();
+    mockedPostMessage
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ messageId: "m1" }) } as Response) // submit
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: "completed", output: { response: "Hi there." } }) } as Response); // status poll
+
+    await store.handleMessageSubmit("hello");
+
+    const messages = store.transcriptStore.messages;
+    expect(messages.some((m) => m.messageContent.content === "Hi there.")).toBe(true);
+    const completed = messages.filter((m) => m.messageContent.description === "Completed response time");
+    expect(completed).toHaveLength(1);
+    const legacy = messages.filter((m) => (m.messageContent.description ?? "").startsWith("Response time"));
+    expect(legacy).toHaveLength(0);
+  });
 });

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -429,10 +429,19 @@ export const AssistantModel = types
 
           self.addDbgMsg("Response from server", formatJsonMessage(data));
 
-          // Tool calls: any user-facing text streamed before this tool call is kept
-          // (finalized in place) and counted as a completed response, not discarded.
+          // Tool calls: any user-facing text the model emitted before this tool call is
+          // kept and counted as a completed response, not discarded. The server attaches
+          // that text as `response` on the tool-call payload, so finalize it here — this
+          // captures it even when streaming display is off or we never polled a transient
+          // streaming update (finalizeStream finalizes an in-progress streamed message in
+          // place, or adds + announces it when nothing was streamed). With no pre-tool
+          // text, just close out any partial stream.
           while (data?.status === "requires_action" && data?.tool_call_id) {
-            self.finishStream(true);
+            if (typeof data.response === "string" && data.response.trim()) {
+              self.finalizeStream(data.response);
+            } else {
+              self.finishStream(true);
+            }
             self.setShowLoadingIndicator(true); // re-show "Processing" for this tool phase
             const toolOutput = yield processToolCall(data as IToolCallData);
             self.addDbgMsg("Tool output generated", formatJsonMessage(toolOutput));

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -100,8 +100,11 @@ export const AssistantModel = types
       }
     },
     finishStream() {
-      // Leave already-shown partial text; just stop tracking the streaming message.
-      self.currentStreamingMessageId = null;
+      if (self.currentStreamingMessageId) {
+        const msg = self.transcriptStore.messages.find((m) => m.id === self.currentStreamingMessageId);
+        self.transcriptStore.finalizeStreamingMessage(self.currentStreamingMessageId, msg?.messageContent.content ?? "");
+        self.currentStreamingMessageId = null;
+      }
     },
   }))
   .actions((self) => ({

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -103,17 +103,20 @@ export const AssistantModel = types
     },
     finalizeStream(fullText: string) {
       if (self.currentStreamingMessageId) {
+        // Streamed: finalize the existing message in place, then log completion after it.
         self.transcriptStore.finalizeStreamingMessage(self.currentStreamingMessageId, fullText);
         self.currentStreamingMessageId = null;
+        timingDebug(self.transcriptStore, "Completed response time", self.responseStartTime);
       } else {
-        // Non-streamed: the whole response arrives at once. Emit "Begin response time"
-        // here too (streaming emits it on the first chunk in ingestStreamChunk) so both
-        // modes log the begin/completed pair — here begin == completed, which is expected.
-        self.transcriptStore.addMessage(DAVAI_SPEAKER, { content: fullText });
+        // Non-streamed: the whole response arrives at once. Log the begin/completed pair
+        // (streaming emits "Begin response time" on the first chunk; here begin == completed)
+        // BEFORE adding the message, so the DAVAI message stays the LAST transcript row —
+        // App's announce/speak effect for non-streamed responses keys off "last message is
+        // a DAVAI message", and trailing debug rows would suppress it.
         timingDebug(self.transcriptStore, "Begin response time", self.responseStartTime);
+        timingDebug(self.transcriptStore, "Completed response time", self.responseStartTime);
+        self.transcriptStore.addMessage(DAVAI_SPEAKER, { content: fullText });
       }
-      // Emit the completed-timing entry for both streamed and non-streamed responses.
-      timingDebug(self.transcriptStore, "Completed response time", self.responseStartTime);
     },
     // Finalize the in-progress streamed message in place, keeping its already-shown
     // text (used for cancel/error/timeout and for user-facing text that precedes a

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -16,6 +16,13 @@ import { postMessage } from "../utils/llm-utils";
 const isToolRequestError = (request: IToolCallData["request"]): request is IToolRequestError =>
   "status" in request && request.status === "error";
 
+// Post a timing debug entry (e.g. "Begin response time"/"Completed response time")
+// measured from the user-submit start. No-op if no start time is recorded.
+const timingDebug = (transcriptStore: any, label: string, startMs: number | null) => {
+  if (startMs == null) return;
+  transcriptStore.addMessage(DEBUG_SPEAKER, { description: label, content: formatElapsedTime(performance.now() - startMs) });
+};
+
 /**
  * AssistantModel encapsulates the AI assistant and its interactions with the user.
  * It includes properties and methods for configuring the assistant, handling chat interactions, and maintaining the assistant's
@@ -47,6 +54,7 @@ export const AssistantModel = types
     graphs: null as any,
     currentStreamingMessageId: null as string | null,
     streamEnabled: true as boolean,
+    responseStartTime: null as number | null,
   }))
   .views((self) => ({
     get isAssistantMocked() {
@@ -75,9 +83,10 @@ export const AssistantModel = types
     },
     ingestStreamChunk(cumulative: string) {
       if (!self.currentStreamingMessageId) {
-        self.showLoadingIndicator = false; // replace the Processing row with the streamed message
+        self.showLoadingIndicator = false; // text has begun; hide the Processing indicator
         self.currentStreamingMessageId =
           self.transcriptStore.addStreamingMessage(DAVAI_SPEAKER, { content: "" });
+        timingDebug(self.transcriptStore, "Begin response time", self.responseStartTime);
       }
       const id = self.currentStreamingMessageId;
       const msg = self.transcriptStore.messages.find((m) => m.id === id);
@@ -88,21 +97,21 @@ export const AssistantModel = types
     finalizeStream(fullText: string) {
       if (self.currentStreamingMessageId) {
         self.transcriptStore.finalizeStreamingMessage(self.currentStreamingMessageId, fullText);
+        timingDebug(self.transcriptStore, "Completed response time", self.responseStartTime);
         self.currentStreamingMessageId = null;
       } else {
         self.transcriptStore.addMessage(DAVAI_SPEAKER, { content: fullText });
       }
     },
-    discardStream() {
-      if (self.currentStreamingMessageId) {
-        self.transcriptStore.removeMessage(self.currentStreamingMessageId);
-        self.currentStreamingMessageId = null;
-      }
-    },
-    finishStream() {
+    // Finalize the in-progress streamed message in place, keeping its already-shown
+    // text (used for cancel/error/timeout and for user-facing text that precedes a
+    // follow-up tool call). Pass logCompleted=true when the text is a completed
+    // user-facing message (so it gets a "Completed response time" entry).
+    finishStream(logCompleted = false) {
       if (self.currentStreamingMessageId) {
         const msg = self.transcriptStore.messages.find((m) => m.id === self.currentStreamingMessageId);
         self.transcriptStore.finalizeStreamingMessage(self.currentStreamingMessageId, msg?.messageContent.content ?? "");
+        if (logCompleted) timingDebug(self.transcriptStore, "Completed response time", self.responseStartTime);
         self.currentStreamingMessageId = null;
       }
     },
@@ -326,6 +335,7 @@ export const AssistantModel = types
           self.messageQueue.push(messageText);
         } else {
           startTime = performance.now();
+          self.responseStartTime = startTime;
           self.isLoadingResponse = true;
 
           // Generate a unique message ID for this request. This lets us cancel the message if needed.
@@ -402,9 +412,10 @@ export const AssistantModel = types
 
           self.addDbgMsg("Response from server", formatJsonMessage(data));
 
-          // Tool calls: a streamed message (if any) is discarded for this turn.
+          // Tool calls: any user-facing text streamed before this tool call is kept
+          // (finalized in place) and counted as a completed response, not discarded.
           while (data?.status === "requires_action" && data?.tool_call_id) {
-            self.discardStream();
+            self.finishStream(true);
             const toolOutput = yield processToolCall(data as IToolCallData);
             self.addDbgMsg("Tool output generated", formatJsonMessage(toolOutput));
             const toolResponseResult: any = yield sendToolOutputToLlm(data.tool_call_id, toolOutput);

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -106,9 +106,13 @@ export const AssistantModel = types
         self.transcriptStore.finalizeStreamingMessage(self.currentStreamingMessageId, fullText);
         self.currentStreamingMessageId = null;
       } else {
+        // Non-streamed: the whole response arrives at once. Emit "Begin response time"
+        // here too (streaming emits it on the first chunk in ingestStreamChunk) so both
+        // modes log the begin/completed pair — here begin == completed, which is expected.
         self.transcriptStore.addMessage(DAVAI_SPEAKER, { content: fullText });
+        timingDebug(self.transcriptStore, "Begin response time", self.responseStartTime);
       }
-      // Emit the timing entry for both streamed and non-streamed responses.
+      // Emit the completed-timing entry for both streamed and non-streamed responses.
       timingDebug(self.transcriptStore, "Completed response time", self.responseStartTime);
     },
     // Finalize the in-progress streamed message in place, keeping its already-shown

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -300,12 +300,15 @@ export const AssistantModel = types
             self.addDbgMsg("Server error processing tool output", output?.error || "Unknown error");
             self.addDavaiMsg("Sorry, I ran into an error processing that request.");
             return;
-          } else if (status === STREAMING_STATUS && self.streamEnabled && typeof output?.response === "string") {
+          } else if (status === STREAMING_STATUS && typeof output?.response === "string") {
+            // Count server streaming as progress regardless of the client's display
+            // preference (same as the message loop), so a long tool-phase response isn't
+            // dropped by the idle budget. Only the on-screen/spoken ingestion is gated.
             if (output.response.length > lastLen) {
               lastLen = output.response.length;
               lastProgressAt = performance.now();
             }
-            self.ingestStreamChunk(output.response);
+            if (self.streamEnabled) self.ingestStreamChunk(output.response);
             yield new Promise((res) => setTimeout(res, 500));
             continue;
           }
@@ -398,12 +401,16 @@ export const AssistantModel = types
               self.addDbgMsg("Server error processing message", output?.error || "Unknown error");
               self.addDavaiMsg("Sorry, I ran into an error processing that request.");
               return;
-            } else if (status === STREAMING_STATUS && self.streamEnabled && typeof output?.response === "string") {
+            } else if (status === STREAMING_STATUS && typeof output?.response === "string") {
+              // Count server streaming as progress regardless of the client's display
+              // preference, so a long response can't hit the idle budget while the server
+              // is steadily generating. Only the on-screen/spoken ingestion is gated on
+              // streamEnabled.
               if (output.response.length > lastLen) {
                 lastLen = output.response.length;
                 lastProgressAt = performance.now(); // progress → extend the budget
               }
-              self.ingestStreamChunk(output.response);
+              if (self.streamEnabled) self.ingestStreamChunk(output.response);
               yield new Promise((res) => setTimeout(res, 500)); // faster cadence while streaming
               continue;
             }
@@ -436,6 +443,10 @@ export const AssistantModel = types
           }
         }
       } catch (err) {
+        // Finalize any in-progress streamed message (keeping its shown text) so an
+        // exception can't leave it stuck isStreaming, which would wedge the a11y
+        // streaming logic and autoscroll on the next turn.
+        self.finishStream();
         console.error("Failed to handle message submit:", err);
         self.addDbgMsg("Failed to handle message submit", formatJsonMessage(err));
       } finally {

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -60,6 +60,13 @@ export const AssistantModel = types
     get isAssistantMocked() {
       const llmData = JSON.parse(self.llmId || "");
       return llmData.id === "mock";
+    },
+    // True whenever a response is being produced and the chat input should stay busy
+    // (disabled, showing Cancel). isLoadingResponse spans the whole real-LLM turn
+    // (including tool calls and streaming, after the "Processing" indicator is cleared);
+    // showLoadingIndicator covers the mock assistant, which never sets isLoadingResponse.
+    get isResponding() {
+      return self.isLoadingResponse || self.showLoadingIndicator;
     }
   }))
   .actions((self) => ({
@@ -327,6 +334,16 @@ export const AssistantModel = types
         self.addDbgMsg(`Response time: ${elapsed}`, elapsed);
         startTime = undefined;
       };
+      // A response is already in flight: queue this message to send once the current turn
+      // finishes, and bail out *before* the request lifecycle below. Its finally block
+      // clears the in-flight flags (isLoadingResponse/currentMessageId), so running it for
+      // a mere queue would prematurely tear down the live request; and starting a second
+      // job here would overwrite currentMessageId and corrupt polling/cancellation.
+      if (self.isLoadingResponse) {
+        self.addDbgMsg("Processing", `User message added to queue: ${messageText}`);
+        self.messageQueue.push(messageText);
+        return;
+      }
       try {
         self.setShowLoadingIndicator(true);
         if (self.isCancelling || self.isResetting) {

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -416,6 +416,7 @@ export const AssistantModel = types
           // (finalized in place) and counted as a completed response, not discarded.
           while (data?.status === "requires_action" && data?.tool_call_id) {
             self.finishStream(true);
+            self.setShowLoadingIndicator(true); // re-show "Processing" for this tool phase
             const toolOutput = yield processToolCall(data as IToolCallData);
             self.addDbgMsg("Tool output generated", formatJsonMessage(toolOutput));
             const toolResponseResult: any = yield sendToolOutputToLlm(data.tool_call_id, toolOutput);

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -248,12 +248,16 @@ export const AssistantModel = types
 
         const { messageId } = yield submissionResponse.json();
 
-        // Poll for the tool response
+        // Poll for the tool response. A tool result triggers the next model turn,
+        // which produces user-facing text (e.g. a graph description) and ALSO streams,
+        // so this loop must handle STREAMING_STATUS the same way the message loop does
+        // (no-progress budget so a long streamed description isn't cut off).
         let data: IMessageResponse | null = null;
-        const deadlineMs = 60_000;
-        const startedAt = performance.now();
+        const idleBudgetMs = 60_000;
+        let lastProgressAt = performance.now();
+        let lastLen = 0;
 
-        while (performance.now() - startedAt < deadlineMs) {
+        while (performance.now() - lastProgressAt < idleBudgetMs) {
           if (self.isCancelling) break;
 
           const statusResponse = yield postMessage({}, `status?messageId=${messageId}`, "GET");
@@ -267,18 +271,29 @@ export const AssistantModel = types
             data = output;
             break;
           } else if (status === "cancelled") {
+            self.finishStream();
             self.addDbgMsg("Tool call job was cancelled on the server", messageId);
             return;
           } else if (status === "error") {
+            self.finishStream();
             self.addDbgMsg("Server error processing tool output", output?.error || "Unknown error");
             self.addDavaiMsg("Sorry, I ran into an error processing that request.");
             return;
+          } else if (status === STREAMING_STATUS && self.streamEnabled && typeof output?.response === "string") {
+            if (output.response.length > lastLen) {
+              lastLen = output.response.length;
+              lastProgressAt = performance.now();
+            }
+            self.ingestStreamChunk(output.response);
+            yield new Promise((res) => setTimeout(res, 500));
+            continue;
           }
 
           yield new Promise((res) => setTimeout(res, 1000));
         }
 
         if (!data) {
+          self.finishStream();
           self.addDbgMsg("Polling expired before tool response received", messageId);
           return;
         }

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -104,11 +104,12 @@ export const AssistantModel = types
     finalizeStream(fullText: string) {
       if (self.currentStreamingMessageId) {
         self.transcriptStore.finalizeStreamingMessage(self.currentStreamingMessageId, fullText);
-        timingDebug(self.transcriptStore, "Completed response time", self.responseStartTime);
         self.currentStreamingMessageId = null;
       } else {
         self.transcriptStore.addMessage(DAVAI_SPEAKER, { content: fullText });
       }
+      // Emit the timing entry for both streamed and non-streamed responses.
+      timingDebug(self.transcriptStore, "Completed response time", self.responseStartTime);
     },
     // Finalize the in-progress streamed message in place, keeping its already-shown
     // text (used for cancel/error/timeout and for user-facing text that precedes a
@@ -323,17 +324,6 @@ export const AssistantModel = types
     });
 
     const handleMessageSubmit = flow(function* (messageText: string) {
-      // Time from when real processing begins to when a terminal outcome is
-      // reached. logResponseTime posts exactly one debug entry (it disarms
-      // itself), and is called just before each terminal output so the entry
-      // appears directly above the response in the transcript.
-      let startTime: number | undefined;
-      const logResponseTime = () => {
-        if (startTime === undefined) return;
-        const elapsed = formatElapsedTime(performance.now() - startTime);
-        self.addDbgMsg(`Response time: ${elapsed}`, elapsed);
-        startTime = undefined;
-      };
       // A response is already in flight: queue this message to send once the current turn
       // finishes, and bail out *before* the request lifecycle below. Its finally block
       // clears the in-flight flags (isLoadingResponse/currentMessageId), so running it for
@@ -351,8 +341,7 @@ export const AssistantModel = types
           self.addDbgMsg(description, `User message added to queue: ${messageText}`);
           self.messageQueue.push(messageText);
         } else {
-          startTime = performance.now();
-          self.responseStartTime = startTime;
+          self.responseStartTime = performance.now();
           self.isLoadingResponse = true;
 
           // Generate a unique message ID for this request. This lets us cancel the message if needed.
@@ -397,12 +386,10 @@ export const AssistantModel = types
               data = output;
               break;
             } else if (status === "cancelled") {
-              logResponseTime();
               self.finishStream();
               self.addDbgMsg("Job was cancelled on the server", messageId);
               return;
             } else if (status === "error") {
-              logResponseTime();
               self.finishStream();
               self.addDbgMsg("Server error processing message", output?.error || "Unknown error");
               self.addDavaiMsg("Sorry, I ran into an error processing that request.");
@@ -421,7 +408,6 @@ export const AssistantModel = types
           }
 
           if (!data) {
-            logResponseTime();
             self.finishStream();
             self.addDbgMsg("Polling expired before response received", messageId);
             return;
@@ -442,23 +428,16 @@ export const AssistantModel = types
           }
 
           if (data?.response) {
-            logResponseTime();
             self.finalizeStream(data.response);
           }
         }
       } catch (err) {
-        // Log before the error message so the timing row sits above it, like the
-        // other terminal branches. Disarms itself, so the finally call is a no-op.
-        logResponseTime();
         console.error("Failed to handle message submit:", err);
         self.addDbgMsg("Failed to handle message submit", formatJsonMessage(err));
       } finally {
         self.isLoadingResponse = false;
         self.setShowLoadingIndicator(false);
         self.currentMessageId = null;
-        // Backstop for a success that produced no chat output (tool-only end).
-        // No-op if an inline call already logged (including the catch path).
-        logResponseTime();
       }
     });
 

--- a/src/models/assistant-model.ts
+++ b/src/models/assistant-model.ts
@@ -1,7 +1,8 @@
 import { types, flow, Instance, getRoot, onSnapshot } from "mobx-state-tree";
 import { nanoid } from "nanoid";
 import { codapInterface } from "@concord-consortium/codap-plugin-api";
-import { DAVAI_SPEAKER, DEBUG_SPEAKER } from "../constants";
+import { DAVAI_SPEAKER, DEBUG_SPEAKER, STREAMING_STATUS } from "../constants";
+import { appendedText } from "../utils/stream-utils";
 import { formatJsonMessage, formatElapsedTime } from "../utils/utils";
 import { getDataContexts, getGraphAttrData, getGraphByID, getTrimmedGraphDetails } from "../utils/codap-api-utils";
 import { isGraphSonifiable } from "../utils/graph-sonification-utils";
@@ -44,6 +45,8 @@ export const AssistantModel = types
     currentMessageId: null as string | null,
     dataContexts: null as any,
     graphs: null as any,
+    currentStreamingMessageId: null as string | null,
+    streamEnabled: true as boolean,
   }))
   .views((self) => ({
     get isAssistantMocked() {
@@ -66,7 +69,40 @@ export const AssistantModel = types
     },
     setThreadId(threadId: string) {
       self.threadId = threadId;
-    }
+    },
+    setStreamEnabled(enabled: boolean) {
+      self.streamEnabled = enabled;
+    },
+    ingestStreamChunk(cumulative: string) {
+      if (!self.currentStreamingMessageId) {
+        self.showLoadingIndicator = false; // replace the Processing row with the streamed message
+        self.currentStreamingMessageId =
+          self.transcriptStore.addStreamingMessage(DAVAI_SPEAKER, { content: "" });
+      }
+      const id = self.currentStreamingMessageId;
+      const msg = self.transcriptStore.messages.find((m) => m.id === id);
+      const shown = msg?.messageContent.content ?? "";
+      const added = appendedText(shown, cumulative);
+      if (added) self.transcriptStore.appendToMessage(id, added);
+    },
+    finalizeStream(fullText: string) {
+      if (self.currentStreamingMessageId) {
+        self.transcriptStore.finalizeStreamingMessage(self.currentStreamingMessageId, fullText);
+        self.currentStreamingMessageId = null;
+      } else {
+        self.transcriptStore.addMessage(DAVAI_SPEAKER, { content: fullText });
+      }
+    },
+    discardStream() {
+      if (self.currentStreamingMessageId) {
+        self.transcriptStore.removeMessage(self.currentStreamingMessageId);
+        self.currentStreamingMessageId = null;
+      }
+    },
+    finishStream() {
+      // Leave already-shown partial text; just stop tracking the streaming message.
+      self.currentStreamingMessageId = null;
+    },
   }))
   .actions((self) => ({
     handleMessageSubmitMockAssistant() {
@@ -211,10 +247,10 @@ export const AssistantModel = types
 
         // Poll for the tool response
         let data: IMessageResponse | null = null;
-        let maxAttempts = 30;
-        let attempt = 0;
+        const deadlineMs = 60_000;
+        const startedAt = performance.now();
 
-        while (attempt < maxAttempts) {
+        while (performance.now() - startedAt < deadlineMs) {
           if (self.isCancelling) break;
 
           const statusResponse = yield postMessage({}, `status?messageId=${messageId}`, "GET");
@@ -237,7 +273,6 @@ export const AssistantModel = types
           }
 
           yield new Promise((res) => setTimeout(res, 1000));
-          attempt++;
         }
 
         if (!data) {
@@ -296,20 +331,21 @@ export const AssistantModel = types
           const { messageId: _messageId } = yield submissionResponse.json();
           self.currentMessageId = _messageId;
 
-          // 2. Poll server until response is ready
+          // 2. Poll server until response is ready. No-progress budget (reset whenever
+          // streamed bytes arrive) instead of a fixed attempt count, so long streams
+          // aren't dropped mid-flight.
           let data: IMessageResponse | null = null;
-          let maxAttempts = 30;
-          let attempt = 0;
+          const idleBudgetMs = 60_000;
+          let lastProgressAt = performance.now();
+          let lastLen = 0;
 
-          while (attempt < maxAttempts) {
+          while (performance.now() - lastProgressAt < idleBudgetMs) {
             if (self.isCancelling) break;
 
             const statusResponse = yield postMessage({}, `status?messageId=${_messageId}`, "GET");
-
             if (!statusResponse.ok) {
               throw new Error(`Failed to fetch status: ${statusResponse.statusText}`);
             }
-
             const { status, output } = yield statusResponse.json();
 
             if (status === "completed") {
@@ -317,45 +353,50 @@ export const AssistantModel = types
               break;
             } else if (status === "cancelled") {
               logResponseTime();
+              self.finishStream();
               self.addDbgMsg("Job was cancelled on the server", messageId);
               return;
             } else if (status === "error") {
               logResponseTime();
+              self.finishStream();
               self.addDbgMsg("Server error processing message", output?.error || "Unknown error");
               self.addDavaiMsg("Sorry, I ran into an error processing that request.");
               return;
+            } else if (status === STREAMING_STATUS && self.streamEnabled && typeof output?.response === "string") {
+              if (output.response.length > lastLen) {
+                lastLen = output.response.length;
+                lastProgressAt = performance.now(); // progress → extend the budget
+              }
+              self.ingestStreamChunk(output.response);
+              yield new Promise((res) => setTimeout(res, 500)); // faster cadence while streaming
+              continue;
             }
 
-            // Wait a moment before retrying
             yield new Promise((res) => setTimeout(res, 1000));
-            attempt++;
           }
 
           if (!data) {
             logResponseTime();
+            self.finishStream();
             self.addDbgMsg("Polling expired before response received", messageId);
             return;
           }
 
           self.addDbgMsg("Response from server", formatJsonMessage(data));
 
-          // Keep processing tool calls until we get a final response
+          // Tool calls: a streamed message (if any) is discarded for this turn.
           while (data?.status === "requires_action" && data?.tool_call_id) {
+            self.discardStream();
             const toolOutput = yield processToolCall(data as IToolCallData);
             self.addDbgMsg("Tool output generated", formatJsonMessage(toolOutput));
-
-            // Send tool response back to server
             const toolResponseResult: any = yield sendToolOutputToLlm(data.tool_call_id, toolOutput);
             self.addDbgMsg("Response to tool output from server", formatJsonMessage(toolResponseResult));
-
-            // Get the next response in the chain
             data = toolResponseResult;
           }
 
-          // Once we're out of the tool call chain, handle the final response.
           if (data?.response) {
             logResponseTime();
-            self.addDavaiMsg(data.response);
+            self.finalizeStream(data.response);
           }
         }
       } catch (err) {

--- a/src/models/chat-transcript-model.test.ts
+++ b/src/models/chat-transcript-model.test.ts
@@ -1,0 +1,33 @@
+import { ChatTranscriptModel } from "./chat-transcript-model";
+
+const make = () => ChatTranscriptModel.create({ messages: [] });
+
+describe("streaming messages", () => {
+  it("addStreamingMessage returns an id and marks the message streaming", () => {
+    const t = make();
+    const id = t.addStreamingMessage("DAVAI", { content: "Hello" });
+    const msg = t.messages.find((m) => m.id === id)!;
+    expect(msg.isStreaming).toBe(true);
+    expect(msg.messageContent.content).toBe("Hello");
+  });
+  it("appendToMessage grows the content", () => {
+    const t = make();
+    const id = t.addStreamingMessage("DAVAI", { content: "Hello" });
+    t.appendToMessage(id, " world");
+    expect(t.messages.find((m) => m.id === id)!.messageContent.content).toBe("Hello world");
+  });
+  it("finalizeStreamingMessage sets content wholesale and clears the flag", () => {
+    const t = make();
+    const id = t.addStreamingMessage("DAVAI", { content: "Hel" });
+    t.finalizeStreamingMessage(id, "Hello world.");
+    const msg = t.messages.find((m) => m.id === id)!;
+    expect(msg.messageContent.content).toBe("Hello world.");
+    expect(msg.isStreaming).toBe(false);
+  });
+  it("removeMessage deletes the message", () => {
+    const t = make();
+    const id = t.addStreamingMessage("DAVAI", { content: "x" });
+    t.removeMessage(id);
+    expect(t.messages.find((m) => m.id === id)).toBeUndefined();
+  });
+});

--- a/src/models/chat-transcript-model.ts
+++ b/src/models/chat-transcript-model.ts
@@ -9,6 +9,7 @@ const MessageModel = types.model("MessageModel", {
   messageContent: types.frozen<MessageContent>(),
   timestamp: types.string,
   id: types.identifier,
+  isStreaming: types.optional(types.boolean, false),
 })
 .views((self) => ({
   get plainTextContent() {
@@ -38,6 +39,23 @@ export const ChatTranscriptModel = types
     },
     clearTranscript() {
       self.messages.clear();
+    },
+    addStreamingMessage(speaker: string, messageContent: MessageContent): string {
+      const id = nanoid();
+      self.messages.push({ speaker, messageContent, timestamp: timeStamp(), id, isStreaming: true });
+      return id;
+    },
+    appendToMessage(id: string, text: string) {
+      const msg = self.messages.find((m) => m.id === id);
+      if (msg) msg.messageContent = { ...msg.messageContent, content: msg.messageContent.content + text };
+    },
+    finalizeStreamingMessage(id: string, content: string) {
+      const msg = self.messages.find((m) => m.id === id);
+      if (msg) { msg.messageContent = { ...msg.messageContent, content }; msg.isStreaming = false; }
+    },
+    removeMessage(id: string) {
+      const msg = self.messages.find((m) => m.id === id);
+      if (msg) self.messages.remove(msg);
     },
   }));
 

--- a/src/services/speech-service.test.ts
+++ b/src/services/speech-service.test.ts
@@ -388,4 +388,17 @@ describe("SpeechService.enqueue", () => {
     expect(mock.spoken).toEqual(["one.", "three."]);
     svc.dispose();
   });
+
+  it("speak() while read-aloud is off does not strand an in-flight utterance", () => {
+    const mock = installSpeechMock();
+    let enabled = true;
+    const svc = new SpeechService(() => enabled, () => 1);
+    svc.enqueue("one.");                 // begins speaking "one." (onstart → speaking true)
+    expect(svc.isSpeaking()).toBe(true);
+    enabled = false;
+    svc.speak("noop while off");         // read-aloud off: must not orphan the live utterance
+    mock.end();                          // "one." finishes → its onend must still flip speaking off
+    expect(svc.isSpeaking()).toBe(false);
+    svc.dispose();
+  });
 });

--- a/src/services/speech-service.test.ts
+++ b/src/services/speech-service.test.ts
@@ -374,4 +374,18 @@ describe("SpeechService.enqueue", () => {
     expect(mock.spoken).toEqual(["one.", "three."]);
     svc.dispose();
   });
+
+  it("stopAndSuppress stops speech and suppresses the rest of the response (Stop-button parity with Escape)", () => {
+    const mock = installSpeechMock();
+    const svc = new SpeechService(() => true, () => 1);
+    svc.enqueue("one.");
+    expect(mock.spoken).toEqual(["one."]);
+    svc.stopAndSuppress();          // what the visible Stop button calls
+    svc.enqueue("two.");            // suppressed → must not resume on the next chunk
+    expect(mock.spoken).toEqual(["one."]);
+    svc.resumeSpeech();             // a new response lifts suppression
+    svc.enqueue("three.");
+    expect(mock.spoken).toEqual(["one.", "three."]);
+    svc.dispose();
+  });
 });

--- a/src/services/speech-service.test.ts
+++ b/src/services/speech-service.test.ts
@@ -360,4 +360,18 @@ describe("SpeechService.enqueue", () => {
     expect(mock.spoken).toEqual(["Processing.", "Sentence one."]);
     svc.dispose();
   });
+
+  it("Escape suppresses the rest of the response until resumeSpeech", () => {
+    const mock = installSpeechMock();
+    const svc = new SpeechService(() => true, () => 1);
+    svc.enqueue("one.");
+    expect(mock.spoken).toEqual(["one."]);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })); // stop + suppress
+    svc.enqueue("two.");             // suppressed → ignored
+    expect(mock.spoken).toEqual(["one."]);
+    svc.resumeSpeech();             // a new response clears suppression
+    svc.enqueue("three.");
+    expect(mock.spoken).toEqual(["one.", "three."]);
+    svc.dispose();
+  });
 });

--- a/src/services/speech-service.test.ts
+++ b/src/services/speech-service.test.ts
@@ -339,4 +339,14 @@ describe("SpeechService.enqueue", () => {
     expect(mock.spoken).toEqual(["one."]);
     svc.dispose();
   });
+
+  it("speak() discards queued chunks (interrupt clears the queue)", () => {
+    const mock = installSpeechMock();
+    const svc = new SpeechService(() => true, () => 1);
+    svc.enqueue("one."); svc.enqueue("two."); // "one." speaking, "two." queued
+    svc.speak("interrupt!");                   // interrupt clears the queue
+    mock.end();                                // onend must NOT start "two."
+    expect(mock.spoken).not.toContain("two.");
+    svc.dispose();
+  });
 });

--- a/src/services/speech-service.test.ts
+++ b/src/services/speech-service.test.ts
@@ -294,3 +294,49 @@ describe("SpeechService", () => {
     });
   });
 });
+
+// Minimal speechSynthesis mock that fires onstart immediately and lets the test
+// drive onend to advance the queue.
+function installSpeechMock() {
+  const spoken: string[] = [];
+  let current: any = null;
+  (global as any).SpeechSynthesisUtterance = class {
+    text: string; rate = 1; onstart: any; onend: any; onerror: any;
+    constructor(t: string) { this.text = t; }
+  };
+  (window as any).speechSynthesis = {
+    speak: (u: any) => { spoken.push(u.text); current = u; u.onstart?.(); },
+    cancel: () => { current = null; },
+  };
+  return { spoken, end: () => current?.onend?.() };
+}
+
+describe("SpeechService.enqueue", () => {
+  it("speaks queued chunks in order, advancing only on onend (no cancel between)", () => {
+    const mock = installSpeechMock();
+    const svc = new SpeechService(() => true, () => 1);
+    svc.enqueue("one."); svc.enqueue("two.");
+    expect(mock.spoken).toEqual(["one."]); // second waits
+    mock.end();
+    expect(mock.spoken).toEqual(["one.", "two."]);
+    svc.dispose();
+  });
+
+  it("no-ops when read-aloud is disabled", () => {
+    const mock = installSpeechMock();
+    const svc = new SpeechService(() => false, () => 1);
+    svc.enqueue("hello.");
+    expect(mock.spoken).toEqual([]);
+    svc.dispose();
+  });
+
+  it("stopSpeech clears the queue so a queued chunk cannot leak after Escape", () => {
+    const mock = installSpeechMock();
+    const svc = new SpeechService(() => true, () => 1);
+    svc.enqueue("one."); svc.enqueue("two.");
+    svc.stopSpeech();
+    mock.end(); // onend from the cancelled utterance must not start "two."
+    expect(mock.spoken).toEqual(["one."]);
+    svc.dispose();
+  });
+});

--- a/src/services/speech-service.test.ts
+++ b/src/services/speech-service.test.ts
@@ -349,4 +349,15 @@ describe("SpeechService.enqueue", () => {
     expect(mock.spoken).not.toContain("two.");
     svc.dispose();
   });
+
+  it("drains chunks enqueued during a speak() utterance (no stranding)", () => {
+    const mock = installSpeechMock();
+    const svc = new SpeechService(() => true, () => 1);
+    svc.speak("Processing.");        // legacy interrupt path (e.g. the loading announcement)
+    svc.enqueue("Sentence one.");    // streamed chunk enqueued while "Processing." is speaking
+    expect(mock.spoken).toEqual(["Processing."]); // sentence waits, does not start yet
+    mock.end();                      // "Processing." onend must drain the queue
+    expect(mock.spoken).toEqual(["Processing.", "Sentence one."]);
+    svc.dispose();
+  });
 });

--- a/src/services/speech-service.ts
+++ b/src/services/speech-service.ts
@@ -9,6 +9,7 @@ export interface ISpeechService {
   dispose(): void;
   onSpeakingChange(callback: (speaking: boolean) => void): () => void;
   enqueue(text: string): void;
+  speakIfIdle(text: string): void;
 }
 
 export class SpeechService implements ISpeechService {
@@ -82,6 +83,18 @@ export class SpeechService implements ISpeechService {
       window.speechSynthesis.cancel();
     }
     this.setSpeaking(false);
+  }
+
+  // True when nothing is being spoken and the queue is empty.
+  private isIdle(): boolean {
+    return !this.utterance && this.queue.length === 0;
+  }
+
+  // Speak only if idle — used for the non-interrupting, looping "Processing"
+  // announcement so it never cuts off streamed speech (it simply skips while
+  // anything else is being spoken/queued, and resumes once idle).
+  speakIfIdle(text: string): void {
+    if (this.isIdle()) this.speak(text);
   }
 
   enqueue(text: string): void {

--- a/src/services/speech-service.ts
+++ b/src/services/speech-service.ts
@@ -10,6 +10,7 @@ export interface ISpeechService {
   onSpeakingChange(callback: (speaking: boolean) => void): () => void;
   enqueue(text: string): void;
   speakIfIdle(text: string): void;
+  resumeSpeech(): void;
 }
 
 export class SpeechService implements ISpeechService {
@@ -17,6 +18,10 @@ export class SpeechService implements ISpeechService {
   private queue: string[] = [];
   private keydownHandler: ((event: KeyboardEvent) => void) | null = null;
   private speaking = false;
+  // Set by Escape: stop reading the rest of the current response. enqueue()/speakIfIdle()
+  // become no-ops until resumeSpeech() (called when a new response starts) or an explicit
+  // speak(). Without this, streamed chunks enqueued after Escape would resume reading.
+  private suppressed = false;
   private speakingChangeCallbacks: Set<(speaking: boolean) => void> = new Set();
   private onErrorCallback: ((error: string) => void) | null = null;
 
@@ -31,16 +36,26 @@ export class SpeechService implements ISpeechService {
 
   private setupEscapeHandler(): void {
     this.keydownHandler = (event: KeyboardEvent) => {
-      // Only handle Escape when speech is playing
-      if (!this.speaking) return;
-
-      if (event.code === "Escape" || event.key === "Escape") {
-        event.preventDefault();
-        this.stopSpeech();
-      }
+      if (event.code !== "Escape" && event.key !== "Escape") return;
+      // Only act when something is being spoken or queued (so Escape passes through
+      // for other uses otherwise).
+      if (!this.speaking && this.queue.length === 0) return;
+      event.preventDefault();
+      this.suppressed = true; // stop reading the rest of this response, not just the current chunk
+      this.stopSpeech();
     };
 
     window.addEventListener("keydown", this.keydownHandler);
+    // DAVAI runs in an iframe; also listen on the parent so Escape works when focus is
+    // in CODAP (mirrors the keyboard-shortcuts service). Guarded for cross-origin.
+    if (window.parent && window.parent !== window) {
+      try { window.parent.addEventListener("keydown", this.keydownHandler); } catch { /* cross-origin */ }
+    }
+  }
+
+  // Re-enable speaking after an Escape suppression (called when a new response begins).
+  resumeSpeech(): void {
+    this.suppressed = false;
   }
 
   private setSpeaking(value: boolean): void {
@@ -51,9 +66,11 @@ export class SpeechService implements ISpeechService {
   }
 
   speak(text: string): void {
-    // An interrupt discards any pending streamed chunks.
+    // An interrupt discards any pending streamed chunks and clears Escape suppression
+    // (an explicit announcement — error, replay, message — should always play).
     this.queue = [];
     this.utterance = null;
+    this.suppressed = false;
     if (!this.getReadAloudEnabled()) {
       return;
     }
@@ -94,10 +111,12 @@ export class SpeechService implements ISpeechService {
   // announcement so it never cuts off streamed speech (it simply skips while
   // anything else is being spoken/queued, and resumes once idle).
   speakIfIdle(text: string): void {
+    if (this.suppressed) return;
     if (this.isIdle()) this.speak(text);
   }
 
   enqueue(text: string): void {
+    if (this.suppressed) return;
     if (!this.getReadAloudEnabled()) return;
     if (!text || text.trim() === "") return;
     if (typeof window === "undefined" || !window.speechSynthesis) {
@@ -145,6 +164,9 @@ export class SpeechService implements ISpeechService {
     this.speakingChangeCallbacks.clear();
     if (this.keydownHandler) {
       window.removeEventListener("keydown", this.keydownHandler);
+      if (window.parent && window.parent !== window) {
+        try { window.parent.removeEventListener("keydown", this.keydownHandler); } catch { /* cross-origin */ }
+      }
       this.keydownHandler = null;
     }
   }

--- a/src/services/speech-service.ts
+++ b/src/services/speech-service.ts
@@ -51,6 +51,7 @@ export class SpeechService implements ISpeechService {
 
   speak(text: string): void {
     this.queue = [];
+    this.utterance = null;
     if (!this.getReadAloudEnabled()) {
       return;
     }

--- a/src/services/speech-service.ts
+++ b/src/services/speech-service.ts
@@ -5,6 +5,7 @@
 export interface ISpeechService {
   speak(text: string): void;
   stopSpeech(): void;
+  stopAndSuppress(): void;
   isSpeaking(): boolean;
   dispose(): void;
   onSpeakingChange(callback: (speaking: boolean) => void): () => void;
@@ -41,8 +42,7 @@ export class SpeechService implements ISpeechService {
       // for other uses otherwise).
       if (!this.speaking && this.queue.length === 0) return;
       event.preventDefault();
-      this.suppressed = true; // stop reading the rest of this response, not just the current chunk
-      this.stopSpeech();
+      this.stopAndSuppress(); // stop reading the rest of this response, not just the current chunk
     };
 
     window.addEventListener("keydown", this.keydownHandler);
@@ -56,6 +56,14 @@ export class SpeechService implements ISpeechService {
   // Re-enable speaking after an Escape suppression (called when a new response begins).
   resumeSpeech(): void {
     this.suppressed = false;
+  }
+
+  // Stop speaking AND suppress the rest of the current streamed response, so chunks
+  // enqueued afterward don't resume playback. Used by both the Escape key and the
+  // visible Stop button. A new response (resumeSpeech) or an explicit speak() lifts it.
+  stopAndSuppress(): void {
+    this.suppressed = true;
+    this.stopSpeech();
   }
 
   private setSpeaking(value: boolean): void {

--- a/src/services/speech-service.ts
+++ b/src/services/speech-service.ts
@@ -74,11 +74,6 @@ export class SpeechService implements ISpeechService {
   }
 
   speak(text: string): void {
-    // An interrupt discards any pending streamed chunks and clears Escape suppression
-    // (an explicit announcement — error, replay, message — should always play).
-    this.queue = [];
-    this.utterance = null;
-    this.suppressed = false;
     if (!this.getReadAloudEnabled()) {
       return;
     }
@@ -89,6 +84,14 @@ export class SpeechService implements ISpeechService {
     if (!text || text.trim() === "") {
       return;
     }
+
+    // An interrupt discards any pending streamed chunks and clears Escape suppression
+    // (an explicit announcement — error, replay, message — should always play). Reset
+    // these only here, after the guards: doing it before the early returns could orphan
+    // an in-flight utterance when read-aloud is off, because the orphaned onend would no
+    // longer match this.utterance and `speaking` would stay stuck true.
+    this.utterance = null;
+    this.suppressed = false;
 
     // Cancel any ongoing speech, then play through the SAME queue mechanism that
     // enqueue() uses (speakNext). This is what makes streamed chunks work: chunks

--- a/src/services/speech-service.ts
+++ b/src/services/speech-service.ts
@@ -50,6 +50,7 @@ export class SpeechService implements ISpeechService {
   }
 
   speak(text: string): void {
+    // An interrupt discards any pending streamed chunks.
     this.queue = [];
     this.utterance = null;
     if (!this.getReadAloudEnabled()) {
@@ -63,36 +64,15 @@ export class SpeechService implements ISpeechService {
       return;
     }
 
-    // Cancel any ongoing speech (but don't call our stopSpeech which resets state)
+    // Cancel any ongoing speech, then play through the SAME queue mechanism that
+    // enqueue() uses (speakNext). This is what makes streamed chunks work: chunks
+    // enqueued while this utterance is speaking would otherwise strand, because
+    // enqueue() only starts speakNext when no utterance is active and speak()'s own
+    // onend never advanced the queue. Routing speak() through speakNext means its
+    // onend drains whatever was enqueued in the meantime.
     window.speechSynthesis.cancel();
-
-    const utterance = new SpeechSynthesisUtterance(text);
-    utterance.rate = this.getPlaybackSpeed();
-    this.utterance = utterance;
-
-    utterance.onstart = () => {
-      if (this.utterance === utterance) {
-        this.setSpeaking(true);
-      }
-    };
-
-    utterance.onend = () => {
-      if (this.utterance === utterance) {
-        this.setSpeaking(false);
-      }
-    };
-
-    utterance.onerror = (event) => {
-      if (this.utterance === utterance) {
-        this.setSpeaking(false);
-      }
-      // Don't report errors for intentional cancellations (user pressed Escape or new speech started)
-      if (event.error !== "canceled" && event.error !== "interrupted") {
-        this.onErrorCallback?.(`Speech synthesis error: ${event.error}`);
-      }
-    };
-
-    window.speechSynthesis.speak(utterance);
+    this.queue = [text];
+    this.speakNext();
   }
 
   stopSpeech(): void {

--- a/src/services/speech-service.ts
+++ b/src/services/speech-service.ts
@@ -8,10 +8,12 @@ export interface ISpeechService {
   isSpeaking(): boolean;
   dispose(): void;
   onSpeakingChange(callback: (speaking: boolean) => void): () => void;
+  enqueue(text: string): void;
 }
 
 export class SpeechService implements ISpeechService {
   private utterance: SpeechSynthesisUtterance | null = null;
+  private queue: string[] = [];
   private keydownHandler: ((event: KeyboardEvent) => void) | null = null;
   private speaking = false;
   private speakingChangeCallbacks: Set<(speaking: boolean) => void> = new Set();
@@ -48,6 +50,7 @@ export class SpeechService implements ISpeechService {
   }
 
   speak(text: string): void {
+    this.queue = [];
     if (!this.getReadAloudEnabled()) {
       return;
     }
@@ -92,10 +95,44 @@ export class SpeechService implements ISpeechService {
   }
 
   stopSpeech(): void {
+    this.queue = [];
+    this.utterance = null;
     if (typeof window !== "undefined" && window.speechSynthesis) {
       window.speechSynthesis.cancel();
     }
     this.setSpeaking(false);
+  }
+
+  enqueue(text: string): void {
+    if (!this.getReadAloudEnabled()) return;
+    if (!text || text.trim() === "") return;
+    if (typeof window === "undefined" || !window.speechSynthesis) {
+      this.onErrorCallback?.("Speech synthesis is not available in this browser.");
+      return;
+    }
+    this.queue.push(text);
+    if (!this.utterance) this.speakNext();
+  }
+
+  private speakNext(): void {
+    const next = this.queue.shift();
+    if (next === undefined) {
+      this.utterance = null;
+      this.setSpeaking(false); // drained
+      return;
+    }
+    const utterance = new SpeechSynthesisUtterance(next);
+    utterance.rate = this.getPlaybackSpeed();
+    this.utterance = utterance;
+    utterance.onstart = () => { if (this.utterance === utterance) this.setSpeaking(true); };
+    utterance.onend = () => { if (this.utterance === utterance) this.speakNext(); };
+    utterance.onerror = (event) => {
+      if (this.utterance === utterance && event.error !== "canceled" && event.error !== "interrupted") {
+        this.onErrorCallback?.(`Speech synthesis error: ${event.error}`);
+      }
+      if (this.utterance === utterance) this.speakNext();
+    };
+    window.speechSynthesis.speak(utterance);
   }
 
   isSpeaking(): boolean {

--- a/src/test-utils/mock-app-config.ts
+++ b/src/test-utils/mock-app-config.ts
@@ -13,6 +13,7 @@ export const mockAppConfig: AppConfigModelSnapshot = {
   playProcessingTone: false,
   playbackSpeed: 1.0,
   readAloudEnabled: false,
+  streamResponses: true,
   llmId: "{ id: \"mock\", name: \"Mock LLM\" }",
   llmList: [
     { id: "mock", provider: "Mock" },

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export type ChatMessage = {
   timestamp: string;
   id: string;
   plainTextContent: string;
+  isStreaming?: boolean;
 };
 
 export type ChatTranscript = {

--- a/src/utils/speech-text.test.ts
+++ b/src/utils/speech-text.test.ts
@@ -1,15 +1,29 @@
-import { forSpeech, chunkToSpeech, TableSpeechState } from "./speech-text";
+import { forSpeech, forSpeechMultiline, chunkToSpeech, TableSpeechState } from "./speech-text";
 
 describe("forSpeech", () => {
   it("strips bold/italic markdown", () => {
     expect(forSpeech("This is **bold** and _italic_.")).toBe("This is bold and italic.");
   });
-  it("voices a bullet marker as • (not the raw symbol)", () => {
-    expect(forSpeech("* First item")).toBe("• First item");
-    expect(forSpeech("- Second item")).toBe("• Second item");
+  it("voices a bullet marker as the spoken word 'bullet' (not a symbol read as 'comma')", () => {
+    expect(forSpeech("* First item")).toBe("bullet First item");
+    expect(forSpeech("- Second item")).toBe("bullet Second item");
   });
   it("preserves a numbered list marker", () => {
     expect(forSpeech("1. Numbered item")).toBe("1. Numbered item");
+  });
+});
+
+describe("forSpeechMultiline", () => {
+  it("voices each bullet line as 'bullet' and keeps numbered markers", () => {
+    expect(forSpeechMultiline("Here are the results:\n- Apple\n- Banana"))
+      .toBe("Here are the results:\nbullet Apple\nbullet Banana");
+    expect(forSpeechMultiline("1. First\n2. Second")).toBe("1. First\n2. Second");
+  });
+  it("drops blank lines and strips inline markdown", () => {
+    expect(forSpeechMultiline("**Bold** intro\n\n- one")).toBe("Bold intro\nbullet one");
+  });
+  it("linearizes a markdown table using its header row", () => {
+    expect(forSpeechMultiline("| A | B |\n|---|---|\n| 1 | 2 |")).toBe("A 1, B 2");
   });
 });
 
@@ -34,6 +48,6 @@ describe("chunkToSpeech table linearization", () => {
 
   it("passes non-table text through forSpeech", () => {
     const state: TableSpeechState = { header: null };
-    expect(chunkToSpeech("* a bullet", state)).toBe("• a bullet");
+    expect(chunkToSpeech("* a bullet", state)).toBe("bullet a bullet");
   });
 });

--- a/src/utils/speech-text.test.ts
+++ b/src/utils/speech-text.test.ts
@@ -1,0 +1,39 @@
+import { forSpeech, chunkToSpeech, TableSpeechState } from "./speech-text";
+
+describe("forSpeech", () => {
+  it("strips bold/italic markdown", () => {
+    expect(forSpeech("This is **bold** and _italic_.")).toBe("This is bold and italic.");
+  });
+  it("voices a bullet marker as • (not the raw symbol)", () => {
+    expect(forSpeech("* First item")).toBe("• First item");
+    expect(forSpeech("- Second item")).toBe("• Second item");
+  });
+  it("preserves a numbered list marker", () => {
+    expect(forSpeech("1. Numbered item")).toBe("1. Numbered item");
+  });
+});
+
+describe("chunkToSpeech table linearization", () => {
+  it("linearizes data rows with header labels, skipping header and separator rows", () => {
+    const state: TableSpeechState = { header: null };
+    expect(chunkToSpeech("| Coaster | State | Top Speed |", state)).toBe(""); // header stored
+    expect(chunkToSpeech("|---|---|---|", state)).toBe("");                    // separator skipped
+    expect(chunkToSpeech("| Fury 325 | NC | 95 mph |", state))
+      .toBe("Coaster Fury 325, State NC, Top Speed 95 mph");
+    expect(chunkToSpeech("| Titan | TX | 85 mph |", state))
+      .toBe("Coaster Titan, State TX, Top Speed 85 mph");
+  });
+
+  it("resets table context when a non-table chunk follows", () => {
+    const state: TableSpeechState = { header: null };
+    chunkToSpeech("| A | B |", state);     // header
+    chunkToSpeech("|---|---|", state);      // separator
+    expect(chunkToSpeech("Here is the summary.", state)).toBe("Here is the summary.");
+    expect(state.header).toBeNull();
+  });
+
+  it("passes non-table text through forSpeech", () => {
+    const state: TableSpeechState = { header: null };
+    expect(chunkToSpeech("* a bullet", state)).toBe("• a bullet");
+  });
+});

--- a/src/utils/speech-text.ts
+++ b/src/utils/speech-text.ts
@@ -6,14 +6,28 @@ const NUMBER_RE = /^(\s*)(\d+)[.)]\s+(.*)$/;
 
 // Strip markdown for the screen reader and TTS so formatting symbols aren't read
 // aloud (e.g. "asterisk asterisk bold"), while KEEPING a spoken indication of list
-// structure: a bullet marker (-, *, +) becomes "•" (voiced "bullet") and a numbered
+// structure: a bullet marker (-, *, +) becomes the spoken word "bullet" and a numbered
 // marker (e.g. "1.") is preserved, with the rest of the item's markdown stripped.
+// (We say the word "bullet" rather than a "•" glyph, which some TTS voices/VoiceOver
+// pronounce as "comma".)
 export function forSpeech(text: string): string {
   const bullet = text.match(BULLET_RE);
-  if (bullet) return `• ${removeMarkdown(bullet[2], STRIP_OPTS)}`;
+  if (bullet) return `bullet ${removeMarkdown(bullet[2], STRIP_OPTS)}`;
   const numbered = text.match(NUMBER_RE);
   if (numbered) return `${numbered[2]}. ${removeMarkdown(numbered[3], STRIP_OPTS)}`;
   return removeMarkdown(text, { stripListLeaders: false, ...STRIP_OPTS });
+}
+
+// Convert a whole multi-line message to spoken text (for non-streamed responses, which
+// arrive all at once). Runs each line through chunkToSpeech with a shared table state,
+// so bullets/numbers and markdown tables are voiced the same way as streamed chunks.
+export function forSpeechMultiline(text: string): string {
+  const state: TableSpeechState = { header: null };
+  return text
+    .split("\n")
+    .map((line) => chunkToSpeech(line, state))
+    .filter((s) => s.trim())
+    .join("\n");
 }
 
 // Parse a markdown table row ("| a | b |") into trimmed cells, or null if not a row.

--- a/src/utils/speech-text.ts
+++ b/src/utils/speech-text.ts
@@ -1,0 +1,61 @@
+import removeMarkdown from "remove-markdown";
+
+const STRIP_OPTS = { useImgAltText: true };
+const BULLET_RE = /^(\s*)[-*+]\s+(.*)$/;
+const NUMBER_RE = /^(\s*)(\d+)[.)]\s+(.*)$/;
+
+// Strip markdown for the screen reader and TTS so formatting symbols aren't read
+// aloud (e.g. "asterisk asterisk bold"), while KEEPING a spoken indication of list
+// structure: a bullet marker (-, *, +) becomes "•" (voiced "bullet") and a numbered
+// marker (e.g. "1.") is preserved, with the rest of the item's markdown stripped.
+export function forSpeech(text: string): string {
+  const bullet = text.match(BULLET_RE);
+  if (bullet) return `• ${removeMarkdown(bullet[2], STRIP_OPTS)}`;
+  const numbered = text.match(NUMBER_RE);
+  if (numbered) return `${numbered[2]}. ${removeMarkdown(numbered[3], STRIP_OPTS)}`;
+  return removeMarkdown(text, { stripListLeaders: false, ...STRIP_OPTS });
+}
+
+// Parse a markdown table row ("| a | b |") into trimmed cells, or null if not a row.
+function parseTableRow(line: string): string[] | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|")) return null;
+  const cells = trimmed.split("|").map((c) => c.trim());
+  if (cells.length && cells[0] === "") cells.shift();
+  if (cells.length && cells[cells.length - 1] === "") cells.pop();
+  return cells;
+}
+
+// A GFM header-separator row, e.g. |---|:--:|
+function isSeparatorRow(cells: string[]): boolean {
+  return cells.length > 0 && cells.every((c) => /^:?-{1,}:?$/.test(c));
+}
+
+export interface TableSpeechState { header: string[] | null; }
+
+// Convert one streamed chunk to spoken text, linearizing markdown table rows into
+// "Header value, Header value, …" using the table's header row (so a screen reader
+// and TTS get column context instead of reading "bar … bar"). Header and separator
+// rows are skipped (return ""). `state` carries the current table's header across
+// chunks; it resets when a non-table chunk is seen.
+export function chunkToSpeech(chunk: string, state: TableSpeechState): string {
+  const cells = parseTableRow(chunk);
+  if (!cells) {
+    state.header = null; // table (if any) ended
+    return forSpeech(chunk);
+  }
+  if (isSeparatorRow(cells)) return "";
+  const stripped = cells.map((c) => removeMarkdown(c, STRIP_OPTS));
+  if (!state.header) {
+    state.header = stripped; // first table row = header → store and skip
+    return "";
+  }
+  const header = state.header;
+  return stripped
+    .map((value, i) => {
+      const label = header[i];
+      return label ? `${label} ${value}`.trim() : value;
+    })
+    .filter((s) => s.trim())
+    .join(", ");
+}

--- a/src/utils/stream-utils.test.ts
+++ b/src/utils/stream-utils.test.ts
@@ -1,0 +1,38 @@
+import { appendedText, extractCompletedChunks } from "./stream-utils";
+
+describe("appendedText", () => {
+  it("returns the new tail when cumulative extends shown", () => {
+    expect(appendedText("Hello", "Hello world")).toBe(" world");
+  });
+  it("returns the full cumulative if it is not a continuation (defensive)", () => {
+    expect(appendedText("Hello", "Goodbye")).toBe("Goodbye");
+  });
+  it("returns empty when nothing new", () => {
+    expect(appendedText("Hello", "Hello")).toBe("");
+  });
+});
+
+describe("extractCompletedChunks", () => {
+  it("emits completed sentences and holds the incomplete tail", () => {
+    const { chunks, remainder } = extractCompletedChunks("One. Two! Three");
+    expect(chunks).toEqual(["One.", "Two!"]);
+    expect(remainder).toBe(" Three");
+  });
+  it("emits a completed list item terminated by a newline", () => {
+    const { chunks, remainder } = extractCompletedChunks("- a\n- b");
+    expect(chunks).toEqual(["- a"]);
+    expect(remainder).toBe("- b");
+  });
+  it("does not split inside an unclosed code block", () => {
+    const { chunks, remainder } = extractCompletedChunks("Here:\n```\nx = 1.\ny = 2");
+    expect(chunks).toEqual(["Here:"]);
+    expect(remainder).toBe("```\nx = 1.\ny = 2");
+  });
+  it("emits a closed code block as one chunk", () => {
+    const { chunks } = extractCompletedChunks("```\nx = 1\n```\n");
+    expect(chunks).toEqual(["```\nx = 1\n```"]);
+  });
+  it("returns no chunks when nothing is complete", () => {
+    expect(extractCompletedChunks("partial")).toEqual({ chunks: [], remainder: "partial" });
+  });
+});

--- a/src/utils/stream-utils.ts
+++ b/src/utils/stream-utils.ts
@@ -1,0 +1,39 @@
+export function appendedText(shown: string, cumulative: string): string {
+  return cumulative.startsWith(shown) ? cumulative.slice(shown.length) : cumulative;
+}
+
+const FENCE = "```";
+
+// Split a buffer into completed sentence/list-item chunks for speech and screen-reader
+// announcement, holding the trailing incomplete unit (and any open code fence) as remainder.
+export function extractCompletedChunks(buffer: string): { chunks: string[]; remainder: string } {
+  const chunks: string[] = [];
+  let rest = buffer;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const trimmedStart = rest.replace(/^\s+/, "");
+    const leadWs = rest.slice(0, rest.length - trimmedStart.length);
+
+    if (trimmedStart.startsWith(FENCE)) {
+      // Code block: only flush when the closing fence + newline is present.
+      const close = trimmedStart.indexOf(FENCE, FENCE.length);
+      const afterClose = close === -1 ? -1 : trimmedStart.indexOf("\n", close + FENCE.length);
+      if (afterClose === -1) break; // unclosed → keep whole thing as remainder
+      chunks.push(trimmedStart.slice(0, afterClose).trimEnd());
+      rest = trimmedStart.slice(afterClose + 1);
+      continue;
+    }
+
+    // Find the next sentence end or newline.
+    const match = trimmedStart.match(/[.!?](?=\s|$)|\n/);
+    if (!match || match.index === undefined) break;
+    const end = match[0] === "\n" ? match.index : match.index + 1;
+    const piece = trimmedStart.slice(0, end).trim();
+    if (piece) chunks.push(piece);
+    rest = trimmedStart.slice(end + (match[0] === "\n" ? 1 : 0));
+    if (leadWs && chunks.length === 0) rest = leadWs + rest;
+  }
+
+  return { chunks, remainder: rest };
+}

--- a/src/utils/stream-utils.ts
+++ b/src/utils/stream-utils.ts
@@ -25,13 +25,20 @@ export function extractCompletedChunks(buffer: string): { chunks: string[]; rema
       continue;
     }
 
-    // Find the next sentence end or newline.
-    const match = trimmedStart.match(/[.!?](?=\s|$)|\n/);
-    if (!match || match.index === undefined) break;
-    const end = match[0] === "\n" ? match.index : match.index + 1;
+    // Skip a leading numbered-list marker (e.g. "1." / "2)") so its period isn't
+    // treated as a sentence end — keep "1. Item" together as one chunk.
+    const marker = trimmedStart.match(/^\d+[.)]\s+/);
+    const searchFrom = marker ? marker[0].length : 0;
+
+    // Find the next sentence end or newline (after any list marker).
+    const rel = trimmedStart.slice(searchFrom).match(/[.!?](?=\s|$)|\n/);
+    if (!rel || rel.index === undefined) break;
+    const isNewline = rel[0] === "\n";
+    const matchIndex = searchFrom + rel.index;
+    const end = isNewline ? matchIndex : matchIndex + 1;
     const piece = trimmedStart.slice(0, end).trim();
     if (piece) chunks.push(piece);
-    rest = trimmedStart.slice(end + (match[0] === "\n" ? 1 : 0));
+    rest = trimmedStart.slice(end + (isNewline ? 1 : 0));
     if (leadWs && chunks.length === 0) rest = leadWs + rest;
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -184,6 +184,12 @@ module.exports = (env, argv) => {
     plugins: [
       new ESLintPlugin({
         extensions: ['ts', 'tsx', 'js', 'jsx'],
+        // Always lint fresh. The result cache is keyed on file content, but the
+        // import/no-extraneous-dependencies rule depends on package.json — so after
+        // adding a dependency, an unchanged importing file would keep showing a stale
+        // "should be listed in dependencies" warning in the dev overlay. Linting this
+        // small codebase each rebuild is cheap and avoids that recurring false alarm.
+        cache: false,
       }),
       new MiniCssExtractPlugin({
         filename: devMode ? 'assets/[name].css' : 'assets/[name].[contenthash].css',


### PR DESCRIPTION
## Summary

Jira: **DAVAI-118**

Streams LLM output to the screen as it is generated — sentence by sentence / bullet by bullet — and routes the same incremental text to the screen-reader live region and the read-aloud (TTS) engine, instead of making the user wait for the entire response. Streaming is the default, with a user toggle to opt out.

This serves DAVAI's accessibility mission: blind/low-vision users hear and read partial responses immediately rather than waiting for a long reply to finish. A hard requirement throughout: **streamed chunks never overwrite speech already in progress** — text is queued, not interrupted.

## How it works

LLM requests are already async + polled. Streaming reuses that loop:

- **Server** (`sam-server`) runs the model via LangGraph and writes incremental partial text to the job row as it generates, using guarded conditional writes and an abort-safe finalize (`job-processor.ts`, `stream-utils.ts`). Cooperative aborts are recorded as `cancelled`.
- **Client** polls `status` as before; on a streaming status it appends only the new text to a streaming transcript message (`assistant-model.ts` poll loop, `stream-utils.ts` append-diff + sentence/bullet chunker).
- **Screen reader / TTS**: `StreamingAnnouncer` emits each newly-completed chunk into a polite `role="log"` region and into an ordered, **non-interrupting** TTS queue on `SpeechService` (`enqueue`/`speakIfIdle`), so new chunks never cut off in-progress speech.

Only user-facing assistant prose is streamed — never tool calls, CODAP requests, or Debug-Log content.

## Notable changes by area

- **Client streaming core**: appendable/finalizable transcript messages (`chat-transcript-model.ts`); poll-loop streaming with a no-progress (wall-clock) budget instead of a fixed attempt count (`assistant-model.ts`).
- **Accessibility**:
  - Markdown stripped for spoken text, but **list structure preserved** (bullets → "•", numbers kept).
  - Full GFM **table support** — rendered via `remark-gfm` and linearized to "Header value, …" for speech.
  - `role="log"` polite region for streamed chunks (better cross-AT behavior, esp. VoiceOver) with the assertive path gated off while streaming.
  - Per-tool-phase "Processing" announcement that loops non-interruptingly and restarts each phase; begin/completed response-timing debug entries.
  - Escape reliably stops read-aloud (also listens on the parent frame, since DAVAI runs in an iframe).
- **UI**: "Stream responses" toggle under Options → Read Responses Aloud (VoiceOver opt-out), speaking indicator floated on top and hidden during processing, table text sized to match surrounding text.
- **Server streaming**: `job-processor.ts` streaming loop with guarded writes + trailing flush; `stream-utils.ts` (text coercion, flush cadence, abort detection).
- **Config**: `streamResponses` flag (default on) in `app-config.json` / `app-config-model.ts`; regenerated `docs/configuration.md`.
- **Build/infra**: `remark-gfm@^4` dependency + Jest ESM allowlist; `cache: false` on the eslint-webpack-plugin to stop stale `no-extraneous-dependencies` dev-overlay warnings.

## Fixes from Codex branch review

- **P1 — input stays busy while streaming**: streaming cleared the Processing indicator on the first chunk, which (because the chat input's disabled + Cancel/Send button were wired to that same flag) re-enabled Send and hid Cancel mid-response, and let a second submit start a concurrent job that overwrote `currentMessageId`. Added an `isResponding` view driving the input state, and an in-flight guard in `handleMessageSubmit` that queues a second submit instead of starting a concurrent job.
- **P2 — Stop button suppresses the rest of the response**: the visible Stop button called `stopSpeech()` (no suppression), so streamed chunks resumed speech on the next chunk. Added `SpeechService.stopAndSuppress()` and routed both Escape and the Stop button through it; a new response lifts the suppression.

## Testing

- Unit suite: **275 passing** (29 suites), including new coverage for the streaming chunker, table linearization, the TTS queue, the streaming announcer, the in-flight submit guard, the `isResponding` view, and `stopAndSuppress`.
- `npm run lint:build` clean (only 2 pre-existing unrelated warnings).
- Manually tested on staging across JAWS and VoiceOver.

## Deploy notes

- **The `sam-server` backend is deployed manually** (CI deploys only the frontend). This PR includes server changes — they must be deployed for live streaming.
- Backward compatible in both directions: an old client polling a new (streaming) server simply ignores partial statuses and reads the final response; a new client against an old (non-streaming) server falls back to the existing wait-for-final behavior.
