### PR TITLE
AgentCore 2/3: CloudFormation staging stack and Cognito public access

### DIFF
--- a/infra/DEPLOYED.md
+++ b/infra/DEPLOYED.md
@@ -1,0 +1,52 @@
+# Deployed — AgentCore staging stack (QA account)
+
+**Source of truth: the `davai-agentcore-staging` CloudFormation stack** (template:
+[cloudformation.yml](cloudformation.yml)), account 816253370536, us-east-1, managed with the
+AWS CLI (profile `agentcore`). The earlier hand-rolled resources (runtime
+`davai_agentcore-0c9quSDd49`, role `davai-agentcore-runtime-execution`) were **deleted
+2026-08-07** and replaced by this stack. The production stack (separate account) is not yet
+created; the template is parameterized for it (`EnvironmentName=production`).
+
+## Stack resources
+| resource | value |
+|---|---|
+| AgentCore runtime | `davai_agentcore_staging-guJgof856F` (image `davai-agentcore-backend:cancelfix-20260807`) |
+| Runtime ARN | `arn:aws:bedrock-agentcore:us-east-1:816253370536:runtime/davai_agentcore_staging-guJgof856F` |
+| Execution role | `davai-agentcore-staging-execution` |
+| Cognito Identity Pool | `us-east-1:f9ef35df-041f-4731-813f-67e998dbc98f` (unauthenticated, **classic flow**) |
+| Unauth role | `davai-agentcore-staging-unauth` — may ONLY `InvokeAgentRuntime` / `InvokeAgentRuntimeWithWebSocketStream` on this runtime |
+| WebSocket endpoint | `wss://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/<url-encoded runtime ARN>/ws` |
+
+ECR repo `davai-agentcore-backend` predates the stack and is referenced via the `ImageUri`
+parameter (images: `cancelfix-20260807` = current, earlier tags = prior).
+Provider keys (OpenAI/Anthropic/Google) are runtime env vars fed from NoEcho stack parameters.
+
+## Deploy / update
+```bash
+./infra/deploy-staging.sh [image-uri]     # reads provider keys from backend/.env
+```
+(or `aws cloudformation deploy|update-stack` with the same parameters; use
+`UsePreviousValue=true` to update without re-supplying keys).
+
+## Public browser access path (verified live 2026-08-07)
+Anonymous client → Cognito `GetId` + `GetOpenIdToken` → `sts:AssumeRoleWithWebIdentity`
+(classic flow — the enhanced flow's service allowlist excludes bedrock-agentcore) → SigV4
+presigned URL (canonical path double-encoded, empty-string payload hash) → WebSocket → runtime
+`/ws` → streaming token frames. Repro, and the client transport's reference implementation:
+```bash
+node scripts/agentcore-cognito-smoke.mjs
+```
+
+## Teardown
+```bash
+aws cloudformation delete-stack --profile agentcore --region us-east-1 --stack-name davai-agentcore-staging
+# ECR repo (outside the stack): aws ecr delete-repository --repository-name davai-agentcore-backend --force
+```
+
+## Production-hardening follow-ups (from the 2026-08-07 code review)
+Deliberately deferred to the production-stack work:
+- Per-identity throttling/quotas (WAF or Cognito-keyed) on top of the anonymous access model —
+  note the legacy SAM setup has the same exposure class (its AUTH_TOKEN ships in the public bundle).
+- Move provider keys from stack parameters to Secrets Manager ARNs (backend already resolves ARNs).
+- Turn the release-build staging fallback in src/utils/agentcore-config.ts from a console
+  warning into a build failure once the production stack exists.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,53 @@
+# infra/ — deploy to the davai dev AWS account
+
+Provisions the new stack: an ECR repo, the AgentCore **runtime execution role**, and the **AgentCore
+Runtime + endpoint** pointing at the pushed container image. Reuses existing dev-account Secrets Manager
+entries for provider API keys. **No Bedrock model access needed** — the agent calls OpenAI/Anthropic/Google
+directly (AgentCore is only the host).
+
+## Prerequisites (not yet installed on the build host — see repo README)
+- **AWS CLI** configured for the davai dev account (a role with `policies/deploy-caller-policy.json`).
+- Either **Docker + ARM64 buildx** (present) **or** the **AgentCore starter toolkit** (`pip install
+  bedrock-agentcore-starter-toolkit`, provides the `agentcore` CLI + CodeBuild builds without local Docker).
+
+## Policies (`policies/`)
+Directly applicable IAM documents (replace `ACCOUNT_ID` / `REGION` / secret names first):
+- `execution-role-trust-policy.json` — trust for `bedrock-agentcore.amazonaws.com`.
+- `execution-role-permissions-policy.json` — least-privilege for the **runtime**: ECR pull, CloudWatch
+  Logs, X-Ray, and `secretsmanager:GetSecretValue` on the provider-key secrets. **No `bedrock:InvokeModel`.**
+- `deploy-caller-policy.json` — what the **deployer** needs: ECR push, `bedrock-agentcore:Create/Update
+  AgentRuntime(+Endpoint)`, and `iam:PassRole` (scoped to the execution role, `PassedToService` =
+  bedrock-agentcore).
+
+## Deploy sequence (P4)
+```bash
+export AWS_REGION=us-east-1 ACCOUNT_ID=<dev-account-id>
+export REPO=davai-agentcore-backend ROLE=davai-agentcore-runtime-execution
+
+# 1. Execution role (once)
+aws iam create-role --role-name "$ROLE" \
+  --assume-role-policy-document file://policies/execution-role-trust-policy.json
+aws iam put-role-policy --role-name "$ROLE" --policy-name execution \
+  --policy-document file://policies/execution-role-permissions-policy.json   # after substituting ACCOUNT_ID/REGION
+
+# 2. ECR repo + push the ARM64 image (built from ../backend)
+aws ecr create-repository --repository-name "$REPO" 2>/dev/null || true
+aws ecr get-login-password | docker login --username AWS --password-stdin \
+  "$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
+docker build --platform linux/arm64 -t "$REPO:latest" ../backend
+docker tag "$REPO:latest" "$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO:latest"
+docker push "$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO:latest"
+
+# 3. Create the AgentCore runtime pointing at the image + execution role.
+#    CONFIRM the exact command/params against the installed CLI before running:
+#      agentcore --help   (starter toolkit: `agentcore configure` then `agentcore launch`)
+#      aws bedrock-agentcore-control help   (raw control-plane: create-agent-runtime)
+#    Left un-fabricated here on purpose — the CLI shape is version-specific and neither
+#    the aws CLI nor the agentcore toolkit is installed on the build host yet.
+```
+
+## Verified now (pre-deploy)
+- ✅ All three policy JSONs are valid and directly applicable (`python3 -m json.tool`).
+- ✅ The backend image builds ARM64 and runs `/ping` locally (see `../backend`).
+- ⏳ Steps 1–3 pend AWS dev-account credentials + CLI install; step 3's exact invocation is confirmed
+  against the installed CLI's `--help` rather than guessed.

--- a/infra/cloudformation.yml
+++ b/infra/cloudformation.yml
@@ -1,0 +1,171 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  DAVAI AgentCore backend stack: AgentCore Runtime (container from ECR), its
+  execution role, and a Cognito Identity Pool whose unauthenticated role may
+  invoke ONLY this stack's runtime (HTTP and WebSocket). One stack per
+  environment: staging lives in the QA account, production in the production
+  account. Deploy/update with `aws cloudformation deploy` (see infra/README.md).
+
+Parameters:
+  EnvironmentName:
+    Type: String
+    Default: staging
+    AllowedValues: [staging, production]
+    Description: Environment this stack serves (staging = QA account).
+  ImageUri:
+    Type: String
+    Description: >-
+      Full ECR image URI for the backend container (ARM64), e.g.
+      816253370536.dkr.ecr.us-east-1.amazonaws.com/davai-agentcore-backend:sse-20260714.
+      The image must exist before the runtime is created/updated.
+  OpenAIApiKey:
+    Type: String
+    NoEcho: true
+    Default: ""
+    Description: OpenAI API key set as a runtime env var (empty disables provider).
+  AnthropicApiKey:
+    Type: String
+    NoEcho: true
+    Default: ""
+    Description: Anthropic API key set as a runtime env var (empty disables provider).
+  GoogleApiKey:
+    Type: String
+    NoEcho: true
+    Default: ""
+    Description: Google API key set as a runtime env var (empty disables provider).
+
+Resources:
+  # ---------------------------------------------------------------- execution
+  RuntimeExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub davai-agentcore-${EnvironmentName}-execution
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: { Service: bedrock-agentcore.amazonaws.com }
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals: { aws:SourceAccount: !Ref AWS::AccountId }
+      Policies:
+        - PolicyName: execution
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: EcrPull
+                Effect: Allow
+                Action:
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                Resource: !Sub arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/davai-agentcore-backend
+              - Sid: EcrAuth
+                Effect: Allow
+                Action: ecr:GetAuthorizationToken
+                Resource: '*'
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:DescribeLogGroups
+                  - logs:DescribeLogStreams
+                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/bedrock-agentcore/*
+              - Sid: XRay
+                Effect: Allow
+                Action:
+                  - xray:PutTraceSegments
+                  - xray:PutTelemetryRecords
+                  - xray:GetSamplingRules
+                  - xray:GetSamplingTargets
+                Resource: '*'
+              - Sid: Metrics
+                Effect: Allow
+                Action: cloudwatch:PutMetricData
+                Resource: '*'
+                Condition:
+                  StringEquals: { cloudwatch:namespace: bedrock-agentcore }
+
+  # ------------------------------------------------------------------ runtime
+  AgentRuntime:
+    Type: AWS::BedrockAgentCore::Runtime
+    Properties:
+      # Name pattern forbids hyphens; env is baked into the name.
+      AgentRuntimeName: !Sub davai_agentcore_${EnvironmentName}
+      Description: !Sub DAVAI AgentCore backend (${EnvironmentName})
+      AgentRuntimeArtifact:
+        ContainerConfiguration:
+          ContainerUri: !Ref ImageUri
+      RoleArn: !GetAtt RuntimeExecutionRole.Arn
+      NetworkConfiguration: { NetworkMode: PUBLIC }
+      # WebSocket bidirectional streaming is part of the HTTP protocol contract
+      # (container serves /ws on 8080); no separate protocol value exists.
+      ProtocolConfiguration: HTTP
+      EnvironmentVariables:
+        PORT: '8080'
+        OPENAI_API_KEY: !Ref OpenAIApiKey
+        ANTHROPIC_API_KEY: !Ref AnthropicApiKey
+        GOOGLE_API_KEY: !Ref GoogleApiKey
+      Tags:
+        Project: davai-agentcore
+        Environment: !Ref EnvironmentName
+
+  # ------------------------------------------------- browser (Cognito) access
+  IdentityPool:
+    Type: AWS::Cognito::IdentityPool
+    Properties:
+      IdentityPoolName: !Sub davai_agentcore_${EnvironmentName}
+      AllowUnauthenticatedIdentities: true
+      # Classic (basic) flow required: the enhanced flow's GetCredentialsForIdentity
+      # scopes credentials to a fixed service allowlist that excludes bedrock-agentcore.
+      # Clients must use GetOpenIdToken + sts:AssumeRoleWithWebIdentity.
+      AllowClassicFlow: true
+
+  UnauthenticatedRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub davai-agentcore-${EnvironmentName}-unauth
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: { Federated: cognito-identity.amazonaws.com }
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals: { cognito-identity.amazonaws.com:aud: !Ref IdentityPool }
+              ForAnyValue:StringLike: { cognito-identity.amazonaws.com:amr: unauthenticated }
+      Policies:
+        - PolicyName: invoke-davai-runtime
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: InvokeThisRuntimeOnly
+                Effect: Allow
+                Action:
+                  - bedrock-agentcore:InvokeAgentRuntime
+                  - bedrock-agentcore:InvokeAgentRuntimeWithWebSocketStream
+                Resource:
+                  - !GetAtt AgentRuntime.AgentRuntimeArn
+                  - !Sub '${AgentRuntime.AgentRuntimeArn}/*'
+
+  IdentityPoolRoles:
+    Type: AWS::Cognito::IdentityPoolRoleAttachment
+    Properties:
+      IdentityPoolId: !Ref IdentityPool
+      Roles:
+        unauthenticated: !GetAtt UnauthenticatedRole.Arn
+
+Outputs:
+  AgentRuntimeArn:
+    Value: !GetAtt AgentRuntime.AgentRuntimeArn
+  UnauthenticatedRoleArn:
+    Description: Role the client assumes via the Cognito classic flow (AssumeRoleWithWebIdentity).
+    Value: !GetAtt UnauthenticatedRole.Arn
+  AgentRuntimeId:
+    Value: !GetAtt AgentRuntime.AgentRuntimeId
+  IdentityPoolId:
+    Value: !Ref IdentityPool
+  WebSocketEndpoint:
+    Description: Data-plane WebSocket URL (presign with SigV4 query params to connect).
+    Value: !Sub wss://bedrock-agentcore.${AWS::Region}.amazonaws.com/runtimes/${AgentRuntime.AgentRuntimeArn}/ws

--- a/infra/deploy-staging.sh
+++ b/infra/deploy-staging.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Deploy/update the DAVAI AgentCore STAGING stack in the QA account.
+# Mirrors the sam-server pattern (CLI-managed stack); provider keys are read
+# from backend/.env so they never appear on the command line or in the shell
+# history. Usage:
+#   ./deploy-staging.sh [image-uri]
+# Requires: AWS CLI profile "agentcore" (QA account 816253370536).
+set -euo pipefail
+cd "$(dirname "$0")"
+
+PROFILE="${AWS_PROFILE:-agentcore}"
+REGION=us-east-1
+STACK=davai-agentcore-staging
+IMAGE_URI="${1:-816253370536.dkr.ecr.us-east-1.amazonaws.com/davai-agentcore-backend:sse-20260714}"
+
+env_val() { grep "^${1}=" ../backend/.env | cut -d= -f2- ; }
+
+aws cloudformation deploy \
+  --profile "$PROFILE" --region "$REGION" \
+  --stack-name "$STACK" \
+  --template-file cloudformation.yml \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --no-fail-on-empty-changeset \
+  --parameter-overrides \
+    EnvironmentName=staging \
+    "ImageUri=$IMAGE_URI" \
+    "OpenAIApiKey=$(env_val OPENAI_API_KEY)" \
+    "AnthropicApiKey=$(env_val ANTHROPIC_API_KEY)" \
+    "GoogleApiKey=$(env_val GOOGLE_API_KEY)"
+
+aws cloudformation describe-stacks \
+  --profile "$PROFILE" --region "$REGION" --stack-name "$STACK" \
+  --query 'Stacks[0].Outputs' --output table

--- a/infra/policies/deploy-caller-policy.json
+++ b/infra/policies/deploy-caller-policy.json
@@ -1,0 +1,43 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EcrPushPull",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage",
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:CreateRepository",
+        "ecr:DescribeRepositories"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "AgentCoreControl",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:CreateAgentRuntime",
+        "bedrock-agentcore:UpdateAgentRuntime",
+        "bedrock-agentcore:CreateAgentRuntimeEndpoint",
+        "bedrock-agentcore:UpdateAgentRuntimeEndpoint",
+        "bedrock-agentcore:GetAgentRuntime",
+        "bedrock-agentcore:ListAgentRuntimes",
+        "bedrock-agentcore:InvokeAgentRuntime"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassExecutionRole",
+      "Effect": "Allow",
+      "Action": ["iam:PassRole"],
+      "Resource": "arn:aws:iam::ACCOUNT_ID:role/davai-agentcore-runtime-execution",
+      "Condition": { "StringEquals": { "iam:PassedToService": "bedrock-agentcore.amazonaws.com" } }
+    }
+  ]
+}

--- a/infra/policies/execution-role-permissions-policy.json
+++ b/infra/policies/execution-role-permissions-policy.json
@@ -1,0 +1,39 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EcrPullImage",
+      "Effect": "Allow",
+      "Action": ["ecr:BatchGetImage", "ecr:GetDownloadUrlForLayer"],
+      "Resource": "arn:aws:ecr:REGION:ACCOUNT_ID:repository/davai-agentcore-backend"
+    },
+    {
+      "Sid": "EcrAuth",
+      "Effect": "Allow",
+      "Action": ["ecr:GetAuthorizationToken"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CloudWatchLogs",
+      "Effect": "Allow",
+      "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents", "logs:DescribeLogStreams"],
+      "Resource": "arn:aws:logs:REGION:ACCOUNT_ID:log-group:/aws/bedrock-agentcore/*"
+    },
+    {
+      "Sid": "XRayTracing",
+      "Effect": "Allow",
+      "Action": ["xray:PutTraceSegments", "xray:PutTelemetryRecords", "xray:GetSamplingRules", "xray:GetSamplingTargets"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ProviderApiKeySecrets",
+      "Effect": "Allow",
+      "Action": ["secretsmanager:GetSecretValue"],
+      "Resource": [
+        "arn:aws:secretsmanager:REGION:ACCOUNT_ID:secret:openai/api-key*",
+        "arn:aws:secretsmanager:REGION:ACCOUNT_ID:secret:anthropic/api-key*",
+        "arn:aws:secretsmanager:REGION:ACCOUNT_ID:secret:google/api-key*"
+      ]
+    }
+  ]
+}

--- a/infra/policies/execution-role-trust-policy.json
+++ b/infra/policies/execution-role-trust-policy.json
@@ -1,0 +1,11 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AgentCoreAssume",
+      "Effect": "Allow",
+      "Principal": { "Service": "bedrock-agentcore.amazonaws.com" },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/scripts/agentcore-bridge.mjs
+++ b/scripts/agentcore-bridge.mjs
@@ -1,0 +1,160 @@
+// Local SigV4 bridge: lets the browser client talk to the DEPLOYED AgentCore runtime
+// using the developer's own AWS credentials (`aws login`) instead of the Cognito
+// identity pool the production transport uses — useful for poking the runtime without
+// depending on the pool. This bridge speaks the backend's WS frame protocol
+// (backend/src/ws.ts) on localhost and forwards each turn via the AWS SDK,
+// requesting `text/event-stream` so the container's SSE frames (sentence-boundary
+// {type:"token"} events, then {type:"result"}) are relayed to the client as they arrive.
+// If the container answers with plain JSON (an image without SSE support), the full
+// body is delivered as a single {type:"result"} frame instead.
+//
+// Credentials come from `aws configure export-credentials --profile agentcore`, so the
+// `aws login` browser session (and its refresh token) keeps working; the bridge
+// re-exports automatically shortly before expiry.
+//
+// Usage:
+//   node scripts/agentcore-bridge.mjs [--port 8100] [--arn <runtime-arn>] [--profile agentcore]
+// then set WS_SERVER_URL=ws://localhost:8100/ws in .env and restart the dev server.
+//
+// Remaining limitations vs. the local backend container:
+// - { type: "seed" } (transcript re-seed) is acknowledged but NOT forwarded: the deployed
+//   /invocations endpoint only accepts turn inputs. Conversation memory instead lives in
+//   the microVM pinned to the runtime session (derived from threadId below).
+// - { type: "cancel" } aborts the HTTP call; the server-side turn still runs to
+//   completion on the microVM (its result is discarded).
+
+import { WebSocketServer } from "ws";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createRequire } from "node:module";
+import { StringDecoder } from "node:string_decoder";
+
+// The SDK client lives in backend/node_modules (a backend devDependency).
+const require = createRequire(new URL("../backend/package.json", import.meta.url));
+const { BedrockAgentCoreClient, InvokeAgentRuntimeCommand } = require("@aws-sdk/client-bedrock-agentcore");
+const ex = promisify(execFile);
+
+const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+const PORT = parseInt(arg("port", "8100"), 10);
+const ARN = arg("arn", "arn:aws:bedrock-agentcore:us-east-1:816253370536:runtime/davai_agentcore_staging-guJgof856F");
+const REGION = arg("region", "us-east-1");
+const PROFILE = arg("profile", process.env.AWS_PROFILE || "agentcore");
+
+// Credential provider backed by the AWS CLI (supports `aws login` sessions). The SDK
+// re-invokes this when the returned expiration approaches.
+async function cliCredentials() {
+  const { stdout } = await ex("aws", ["configure", "export-credentials", "--profile", PROFILE]);
+  const c = JSON.parse(stdout);
+  return {
+    accessKeyId: c.AccessKeyId,
+    secretAccessKey: c.SecretAccessKey,
+    sessionToken: c.SessionToken,
+    expiration: c.Expiration ? new Date(c.Expiration) : undefined,
+  };
+}
+
+const client = new BedrockAgentCoreClient({ region: REGION, credentials: cliCredentials });
+
+// AgentCore runtime session ids must be >= 33 chars; derive a stable one from threadId
+// so every turn of a client thread lands on the same pinned microVM.
+const sessionIdFor = (threadId) => `sess-${String(threadId)}`.padEnd(36, "0").slice(0, 100);
+
+// Feed SSE bytes in; invoke onFrame with each complete `data: {...}` event's parsed JSON.
+function sseParser(onFrame) {
+  let buf = "";
+  return (chunkText) => {
+    buf += chunkText;
+    let sep;
+    while ((sep = buf.indexOf("\n\n")) >= 0) {
+      const block = buf.slice(0, sep);
+      buf = buf.slice(sep + 2);
+      const data = block
+        .split("\n")
+        .filter((l) => l.startsWith("data:"))
+        .map((l) => l.slice(5).trimStart())
+        .join("\n");
+      if (!data) continue;
+      try { onFrame(JSON.parse(data)); } catch { /* ignore malformed event */ }
+    }
+  };
+}
+
+// Loopback only: this process signs requests with the developer's AWS credentials,
+// so it must never be reachable from other machines on the network.
+const wss = new WebSocketServer({ host: "127.0.0.1", port: PORT, path: "/ws" });
+
+wss.on("connection", (ws) => {
+  const send = (obj) => { if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(obj)); };
+  let inflight = null; // AbortController of the current turn
+
+  ws.on("message", async (raw) => {
+    let frame;
+    try {
+      frame = JSON.parse(raw.toString());
+    } catch {
+      return send({ type: "error", error: "invalid JSON frame" });
+    }
+
+    if (frame?.type === "cancel") {
+      // Mirror the real backend (runner.ts returns {status:"cancelled"} on abort, ws.ts
+      // sends it as a result frame): the client's suspended turn must RESOLVE, not hang.
+      // The deployed microVM still runs its turn to completion; the result is discarded.
+      if (inflight) {
+        inflight.abort();
+        inflight = null;
+        send({ type: "result", output: { status: "cancelled" } });
+      }
+      return;
+    }
+
+    if (frame?.type === "seed") {
+      console.warn(`[bridge] seed frame ignored (deployed /invocations cannot re-seed; relying on microVM session memory)`);
+      return send({ type: "seeded", count: 0 });
+    }
+
+    inflight?.abort(); // supersede any prior in-flight turn on this socket
+    const controller = new AbortController();
+    inflight = controller;
+    const t0 = performance.now();
+    let tokens = 0;
+
+    try {
+      const out = await client.send(new InvokeAgentRuntimeCommand({
+        agentRuntimeArn: ARN,
+        runtimeSessionId: sessionIdFor(frame.threadId),
+        contentType: "application/json",
+        accept: "text/event-stream",
+        payload: JSON.stringify(frame),
+      }), { abortSignal: controller.signal });
+
+      const streaming = (out.contentType || "").includes("text/event-stream");
+      if (streaming) {
+        const feed = sseParser((evt) => {
+          if (evt?.type === "token") tokens++;
+          send(evt); // token / result / error frames pass through unchanged
+        });
+        // StringDecoder holds partial multi-byte sequences across chunk boundaries;
+        // decoding each chunk independently would corrupt split UTF-8 characters.
+        const decoder = new StringDecoder("utf8");
+        for await (const chunk of out.response) feed(decoder.write(Buffer.from(chunk)));
+        feed(decoder.end());
+      } else {
+        const parts = [];
+        for await (const chunk of out.response) parts.push(Buffer.from(chunk));
+        send({ type: "result", output: JSON.parse(Buffer.concat(parts).toString("utf8")) });
+      }
+      console.log(`[bridge] turn ${frame.kind === "tool" ? "(tool) " : ""}thread=${frame.threadId} ${(performance.now() - t0).toFixed(0)}ms ${streaming ? `(${tokens} token frames)` : "(no stream)"}`);
+    } catch (e) {
+      if (controller.signal.aborted) return; // cancelled locally; drop silently
+      console.error(`[bridge] invoke failed:`, e?.message || e);
+      send({ type: "error", error: e?.message || String(e) });
+    } finally {
+      if (inflight === controller) inflight = null;
+    }
+  });
+
+  ws.on("close", () => inflight?.abort());
+});
+
+console.log(`agentcore-bridge listening on ws://localhost:${PORT}/ws`);
+console.log(`  forwarding to ${ARN} (region ${REGION}, profile ${PROFILE}, SSE requested)`);

--- a/scripts/agentcore-cognito-smoke.mjs
+++ b/scripts/agentcore-cognito-smoke.mjs
@@ -1,0 +1,134 @@
+// Smoke test for the PUBLIC browser access path to the AgentCore staging stack:
+//   Cognito unauthenticated identity -> temp AWS credentials -> SigV4 presigned
+//   WebSocket URL -> AgentCore data plane -> container /ws.
+// This is exactly the sequence the deployed DAVAI client performs (no AWS SDK,
+// plain fetch + HMAC), so it doubles as a reference implementation for the
+// client transport. Requires no AWS profile — the whole point is that it runs
+// with only the public identity-pool id.
+//
+// Usage: node scripts/agentcore-cognito-smoke.mjs [message]
+import { createHmac, createHash, randomUUID } from "node:crypto";
+import WebSocket from "ws";
+
+const REGION = "us-east-1";
+const IDENTITY_POOL_ID = "us-east-1:f9ef35df-041f-4731-813f-67e998dbc98f";
+const RUNTIME_ARN = "arn:aws:bedrock-agentcore:us-east-1:816253370536:runtime/davai_agentcore_staging-guJgof856F";
+const MESSAGE = process.argv[2] || "Reply with exactly: pong";
+
+// ---- 1. Cognito unauthenticated credentials (plain REST, no SDK) ------------
+async function cognito(target, body) {
+  const res = await fetch(`https://cognito-identity.${REGION}.amazonaws.com/`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-amz-json-1.1",
+      "x-amz-target": `AWSCognitoIdentityService.${target}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`${target} failed: ${res.status} ${await res.text()}`);
+  return res.json();
+}
+
+// Classic (basic) flow: the enhanced flow's GetCredentialsForIdentity scopes
+// credentials to a fixed AWS service allowlist that EXCLUDES bedrock-agentcore,
+// so we exchange an OpenID token with STS directly (AllowClassicFlow on the pool).
+const UNAUTH_ROLE_ARN = "arn:aws:iam::816253370536:role/davai-agentcore-staging-unauth";
+
+const { IdentityId } = await cognito("GetId", { IdentityPoolId: IDENTITY_POOL_ID });
+const { Token } = await cognito("GetOpenIdToken", { IdentityId });
+
+const stsRes = await fetch(`https://sts.${REGION}.amazonaws.com/`, {
+  method: "POST",
+  headers: { "content-type": "application/x-www-form-urlencoded" },
+  body: new URLSearchParams({
+    Action: "AssumeRoleWithWebIdentity",
+    Version: "2011-06-15",
+    RoleArn: UNAUTH_ROLE_ARN,
+    RoleSessionName: "davai-web",
+    WebIdentityToken: Token,
+    DurationSeconds: "3600",
+  }),
+});
+const stsXml = await stsRes.text();
+if (!stsRes.ok) throw new Error(`STS failed: ${stsRes.status} ${stsXml.slice(0, 300)}`);
+const xmlVal = (tag) => stsXml.match(new RegExp(`<${tag}>([^<]+)</${tag}>`))?.[1];
+const Credentials = {
+  AccessKeyId: xmlVal("AccessKeyId"),
+  SecretKey: xmlVal("SecretAccessKey"),
+  SessionToken: xmlVal("SessionToken"),
+};
+console.log(`[cognito] identity ${IdentityId}, classic-flow credentials expire ${xmlVal("Expiration")}`);
+
+// ---- 2. SigV4 presigned WebSocket URL --------------------------------------
+const hmac = (key, data) => createHmac("sha256", key).update(data).digest();
+const sha256hex = (data) => createHash("sha256").update(data).digest("hex");
+// RFC 3986 encoding (SigV4 requires !'()* encoded too)
+const enc = (s) => encodeURIComponent(s).replace(/[!'()*]/g, (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase());
+
+function presignWsUrl({ accessKeyId, secretKey, sessionToken, runtimeArn, sessionId, expires = 300 }) {
+  const host = `bedrock-agentcore.${REGION}.amazonaws.com`;
+  const service = "bedrock-agentcore";
+  const path = `/runtimes/${enc(runtimeArn)}/ws`;
+  // Canonical URI matches botocore SigV4QueryAuth: the request path's %XX
+  // sequences are encoded AGAIN (double encoding), payload hash is sha256("").
+  const canonicalPath = `/runtimes/${enc(enc(runtimeArn))}/ws`;
+  const now = new Date();
+  const amzDate = now.toISOString().replace(/[-:]/g, "").slice(0, 15) + "Z";
+  const dateStamp = amzDate.slice(0, 8);
+  const scope = `${dateStamp}/${REGION}/${service}/aws4_request`;
+
+  const query = {
+    "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+    "X-Amz-Credential": `${accessKeyId}/${scope}`,
+    "X-Amz-Date": amzDate,
+    "X-Amz-Expires": String(expires),
+    "X-Amz-Security-Token": sessionToken,
+    "X-Amz-SignedHeaders": "host",
+    "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": sessionId,
+  };
+  const canonicalQuery = Object.keys(query).sort()
+    .map((k) => `${enc(k)}=${enc(query[k])}`)
+    .join("&");
+  // Payload hash: sha256 of the empty string (botocore SigV4QueryAuth; the
+  // S3-style "UNSIGNED-PAYLOAD" sentinel is rejected here).
+  const canonicalRequest = ["GET", canonicalPath, canonicalQuery, `host:${host}\n`, "host", sha256hex("")].join("\n");
+  const stringToSign = ["AWS4-HMAC-SHA256", amzDate, scope, sha256hex(canonicalRequest)].join("\n");
+  const kSigning = hmac(hmac(hmac(hmac(`AWS4${secretKey}`, dateStamp), REGION), service), "aws4_request");
+  const signature = createHmac("sha256", kSigning).update(stringToSign).digest("hex");
+  return `wss://${host}${path}?${canonicalQuery}&X-Amz-Signature=${signature}`;
+}
+
+const sessionId = `smoke-${randomUUID()}`; // >=33 chars
+const wsUrl = presignWsUrl({
+  accessKeyId: Credentials.AccessKeyId,
+  secretKey: Credentials.SecretKey,
+  sessionToken: Credentials.SessionToken,
+  runtimeArn: RUNTIME_ARN,
+  sessionId,
+});
+console.log(`[presign] url ready (session ${sessionId})`);
+
+// ---- 3. Connect and run one turn -------------------------------------------
+const ws = new WebSocket(wsUrl);
+const t0 = Date.now();
+ws.on("open", () => {
+  console.log(`[ws] connected in ${Date.now() - t0}ms`);
+  ws.send(JSON.stringify({
+    llmId: JSON.stringify({ id: "gpt-4o-mini", provider: "OpenAI" }),
+    threadId: sessionId,
+    message: MESSAGE,
+  }));
+});
+ws.on("message", (d) => {
+  const f = JSON.parse(d.toString());
+  console.log(`[ws] ${Date.now() - t0}ms [${f.type}] ${(f.text || JSON.stringify(f.output) || f.error || "").slice(0, 100)}`);
+  if (f.type === "result" || f.type === "error") { ws.close(); process.exit(f.type === "error" ? 1 : 0); }
+});
+ws.on("unexpected-response", (_req, res) => {
+  console.error(`[ws] handshake failed: HTTP ${res.statusCode} ${res.headers["x-amzn-errortype"] || ""}`);
+  let body = "";
+  res.on("data", (c) => (body += c));
+  res.on("end", () => { console.error(body.slice(0, 300)); process.exit(1); });
+});
+ws.on("error", (e) => { console.error(`[ws] error: ${e.message}`); process.exit(1); });
+setTimeout(() => { console.error("[ws] timeout"); process.exit(1); }, 60000);


### PR DESCRIPTION
Second of three chained PRs splitting #115 (chain: #116 → this → #115). **This is the security-review PR** — the access model for the public plugin.

- `infra/cloudformation.yml` — the CLI-managed stack (mirrors the sam-server pattern): AgentCore runtime (native `AWS::BedrockAgentCore::Runtime`), execution role (ECR pull scoped to the one repo, logs, X-Ray), and a **Cognito Identity Pool with unauthenticated identities** whose role is scoped to `InvokeAgentRuntime` + `InvokeAgentRuntimeWithWebSocketStream` on *this stack's runtime only*. Classic flow enabled (the enhanced flow's service allowlist excludes bedrock-agentcore). Provider keys are NoEcho parameters; Secrets Manager migration is a tracked follow-up in `infra/DEPLOYED.md`.
- Deployed as `davai-agentcore-staging` in the QA account (see `infra/DEPLOYED.md` for live state, deploy/teardown, and the pre-production follow-up list). Parameterized for a future production stack.
- `scripts/agentcore-cognito-smoke.mjs` — proves the full anonymous path (Cognito → STS → pure-JS SigV4 presigned WebSocket → streamed turn); doubles as the client transport's reference implementation. `scripts/agentcore-bridge.mjs` — localhost-only developer-credential bridge.

Anonymous invocation is the designed access model (same exposure class as today's bundle-embedded server token); server-side allowlists and caps land in #116, per-identity quotas are a pre-production follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)